### PR TITLE
fix: /lib64/libc.so.6: version `GLIBC_2.32' not found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
-      CGO_ENABLED: ${{ matrix.cgo_enabled }}
+      CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
       CC: ${{ matrix.cc }}
 
     steps:


### PR DESCRIPTION
This PR aims to fix a issue about runtime error as follows, `CGO` related

```
daed: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by daed)
```