### PR TITLE
fix: limit the tproxy port input range, add descriptive help texts

### DIFF
--- a/src/components/ConfigFormModal.tsx
+++ b/src/components/ConfigFormModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Accordion,
   ActionIcon,
   Checkbox,
   Drawer,
@@ -9,7 +10,6 @@ import {
   NumberInput,
   Radio,
   Select,
-  SimpleGrid,
   Slider,
   Stack,
   TextInput,
@@ -252,162 +252,209 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
         <Stack>
           <TextInput label={t('name')} withAsterisk {...form.getInputProps('name')} disabled={!!editingID} />
 
-          <Stack>
-            <Input.Label>{t('logLevel')}</Input.Label>
+          <Accordion
+            variant="separated"
+            multiple
+            defaultValue={[
+              'software-options',
+              'interface-and-kernel-options',
+              'node-connectivity-check',
+              'connecting-options',
+            ]}
+          >
+            <Accordion.Item value="software-options">
+              <Accordion.Control>{t('software options')}</Accordion.Control>
 
-            <div className="px-4 pb-4">
-              <Slider
-                min={0}
-                max={4}
-                step={1}
-                label={null}
-                marks={logLevelMarks}
-                {...form.getInputProps('logLevelNumber')}
-              />
-            </div>
-          </Stack>
+              <Accordion.Panel>
+                <Stack>
+                  <NumberInput
+                    label={t('tproxyPort')}
+                    description={t('descriptions.tproxyPort')}
+                    withAsterisk
+                    min={0}
+                    max={65535}
+                    {...form.getInputProps('tproxyPort')}
+                  />
 
-          <Radio.Group label={t('dialMode')} {...form.getInputProps('dialMode')}>
-            <Group mt="xs">
-              <Radio value={DialMode.ip} label={DialMode.ip} description={t('descriptions.dialMode.ip')} />
-              <Radio value={DialMode.domain} label={DialMode.domain} description={t('descriptions.dialMode.domain')} />
-              <Radio
-                value={DialMode.domainP}
-                label={DialMode.domainP}
-                description={t('descriptions.dialMode.domain+')}
-              />
-              <Radio
-                value={DialMode.domainPP}
-                label={DialMode.domainPP}
-                description={t('descriptions.dialMode.domain++')}
-              />
-            </Group>
-          </Radio.Group>
+                  <Checkbox
+                    label={t('tproxyPortProtect')}
+                    description={t('descriptions.tproxyPortProtect')}
+                    {...form.getInputProps('tproxyPortProtect', {
+                      type: 'checkbox',
+                    })}
+                  />
 
-          <NumberInput
-            label={t('tproxyPort')}
-            description={t('descriptions.tproxyPort')}
-            withAsterisk
-            min={0}
-            max={65535}
-            {...form.getInputProps('tproxyPort')}
-          />
+                  <Stack>
+                    <Input.Label>{t('logLevel')}</Input.Label>
 
-          <Checkbox
-            label={t('tproxyPortProtect')}
-            description={t('descriptions.tproxyPortProtect')}
-            {...form.getInputProps('tproxyPortProtect', {
-              type: 'checkbox',
-            })}
-          />
+                    <div className="px-4 pb-4">
+                      <Slider
+                        min={0}
+                        max={4}
+                        step={1}
+                        label={null}
+                        marks={logLevelMarks}
+                        {...form.getInputProps('logLevelNumber')}
+                      />
+                    </div>
+                  </Stack>
 
-          <MultiSelect
-            label={t('wanInterface')}
-            description={t('descriptions.wanInterface')}
-            withAsterisk
-            data={wanInterfacesData}
-            {...form.getInputProps('wanInterface')}
-          />
+                  <Checkbox
+                    label={t('disableWaitingNetwork')}
+                    description={t('descriptions.disableWaitingNetwork')}
+                    {...form.getInputProps('disableWaitingNetwork', {
+                      type: 'checkbox',
+                    })}
+                  />
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
 
-          <MultiSelect
-            label={t('lanInterface')}
-            description={t('descriptions.lanInterface')}
-            data={lanInterfacesData}
-            {...form.getInputProps('lanInterface')}
-          />
+            <Accordion.Item value="interface-and-kernel-options">
+              <Accordion.Control>{t('interface and kernel options')}</Accordion.Control>
 
-          <NumberInput
-            label={`${t('checkInterval')} (s)`}
-            withAsterisk
-            {...form.getInputProps('checkIntervalSeconds')}
-          />
+              <Accordion.Panel>
+                <Stack>
+                  <MultiSelect
+                    label={t('lanInterface')}
+                    description={t('descriptions.lanInterface')}
+                    data={lanInterfacesData}
+                    {...form.getInputProps('lanInterface')}
+                  />
 
-          <NumberInput
-            label={`${t('checkTolerance')} (ms)`}
-            description={t('descriptions.checkTolerance')}
-            withAsterisk
-            step={500}
-            {...form.getInputProps('checkToleranceMS')}
-          />
+                  <MultiSelect
+                    label={t('wanInterface')}
+                    description={t('descriptions.wanInterface')}
+                    withAsterisk
+                    data={wanInterfacesData}
+                    {...form.getInputProps('wanInterface')}
+                  />
 
-          <NumberInput
-            label={`${t('sniffingTimeout')} (ms)`}
-            description={t('descriptions.sniffingTimeout')}
-            step={500}
-            {...form.getInputProps('sniffingTimeoutMS')}
-          />
+                  <Checkbox
+                    label={t('autoConfigKernelParameter')}
+                    description={t('descriptions.autoConfigKernelParameter')}
+                    {...form.getInputProps('autoConfigKernelParameter', {
+                      type: 'checkbox',
+                    })}
+                  />
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
 
-          <Select
-            label={t('tcpCheckHttpMethod')}
-            description={t('descriptions.tcpCheckHttpMethod')}
-            data={Object.values(TcpCheckHttpMethod).map((tcpCheckHttpMethod) => ({
-              label: tcpCheckHttpMethod,
-              value: tcpCheckHttpMethod,
-            }))}
-            {...form.getInputProps('tcpCheckHttpMethod')}
-          />
+            <Accordion.Item value="node-connectivity-check">
+              <Accordion.Control>{t('node connectivity check')}</Accordion.Control>
 
-          <InputList
-            form={form}
-            label={t('udpCheckDns')}
-            description={t('descriptions.udpCheckDns')}
-            fieldName="udpCheckDns"
-            values={form.values.udpCheckDns}
-          />
+              <Accordion.Panel>
+                <Stack>
+                  <InputList
+                    form={form}
+                    label={t('tcpCheckUrl')}
+                    description={t('descriptions.tcpCheckUrl')}
+                    fieldName="tcpCheckUrl"
+                    values={form.values.tcpCheckUrl}
+                  />
 
-          <InputList
-            form={form}
-            label={t('tcpCheckUrl')}
-            description={t('descriptions.tcpCheckUrl')}
-            fieldName="tcpCheckUrl"
-            values={form.values.tcpCheckUrl}
-          />
+                  <Select
+                    label={t('tcpCheckHttpMethod')}
+                    description={t('descriptions.tcpCheckHttpMethod')}
+                    data={Object.values(TcpCheckHttpMethod).map((tcpCheckHttpMethod) => ({
+                      label: tcpCheckHttpMethod,
+                      value: tcpCheckHttpMethod,
+                    }))}
+                    {...form.getInputProps('tcpCheckHttpMethod')}
+                  />
 
-          <Select
-            label={t('tlsImplementation')}
-            description={t('descriptions.tlsImplementation')}
-            data={Object.values(TLSImplementation).map((tlsImplementation) => ({
-              label: tlsImplementation,
-              value: tlsImplementation,
-            }))}
-            {...form.getInputProps('tlsImplementation')}
-          />
+                  <InputList
+                    form={form}
+                    label={t('udpCheckDns')}
+                    description={t('descriptions.udpCheckDns')}
+                    fieldName="udpCheckDns"
+                    values={form.values.udpCheckDns}
+                  />
 
-          <Select
-            label={t('utlsImitate')}
-            description={t('descriptions.utlsImitate')}
-            data={Object.values(UTLSImitate).map((utlsImitate) => ({
-              label: utlsImitate,
-              value: utlsImitate,
-            }))}
-            {...form.getInputProps('utlsImitate')}
-          />
+                  <NumberInput
+                    label={`${t('checkInterval')} (s)`}
+                    withAsterisk
+                    {...form.getInputProps('checkIntervalSeconds')}
+                  />
 
-          <SimpleGrid cols={2}>
-            <Checkbox
-              label={t('allowInsecure')}
-              description={t('descriptions.allowInsecure')}
-              {...form.getInputProps('allowInsecure', {
-                type: 'checkbox',
-              })}
-            />
+                  <NumberInput
+                    label={`${t('checkTolerance')} (ms)`}
+                    description={t('descriptions.checkTolerance')}
+                    withAsterisk
+                    step={500}
+                    {...form.getInputProps('checkToleranceMS')}
+                  />
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
 
-            <Checkbox
-              label={t('autoConfigKernelParameter')}
-              description={t('descriptions.autoConfigKernelParameter')}
-              {...form.getInputProps('autoConfigKernelParameter', {
-                type: 'checkbox',
-              })}
-            />
+            <Accordion.Item value="connecting-options">
+              <Accordion.Control>{t('connecting options')}</Accordion.Control>
 
-            <Checkbox
-              label={t('disableWaitingNetwork')}
-              description={t('descriptions.disableWaitingNetwork')}
-              {...form.getInputProps('disableWaitingNetwork', {
-                type: 'checkbox',
-              })}
-            />
-          </SimpleGrid>
+              <Accordion.Panel>
+                <Stack>
+                  <Radio.Group label={t('dialMode')} {...form.getInputProps('dialMode')}>
+                    <Group mt="xs">
+                      <Radio value={DialMode.ip} label={DialMode.ip} description={t('descriptions.dialMode.ip')} />
+                      <Radio
+                        value={DialMode.domain}
+                        label={DialMode.domain}
+                        description={t('descriptions.dialMode.domain')}
+                      />
+                      <Radio
+                        value={DialMode.domainP}
+                        label={DialMode.domainP}
+                        description={t('descriptions.dialMode.domain+')}
+                      />
+                      <Radio
+                        value={DialMode.domainPP}
+                        label={DialMode.domainPP}
+                        description={t('descriptions.dialMode.domain++')}
+                      />
+                    </Group>
+                  </Radio.Group>
+
+                  <Checkbox
+                    label={t('allowInsecure')}
+                    description={t('descriptions.allowInsecure')}
+                    {...form.getInputProps('allowInsecure', {
+                      type: 'checkbox',
+                    })}
+                  />
+
+                  <NumberInput
+                    label={`${t('sniffingTimeout')} (ms)`}
+                    description={t('descriptions.sniffingTimeout')}
+                    step={500}
+                    {...form.getInputProps('sniffingTimeoutMS')}
+                  />
+
+                  <Select
+                    label={t('tlsImplementation')}
+                    description={t('descriptions.tlsImplementation')}
+                    data={Object.values(TLSImplementation).map((tlsImplementation) => ({
+                      label: tlsImplementation,
+                      value: tlsImplementation,
+                    }))}
+                    {...form.getInputProps('tlsImplementation')}
+                  />
+
+                  {form.values.tlsImplementation === TLSImplementation.utls && (
+                    <Select
+                      label={t('utlsImitate')}
+                      description={t('descriptions.utlsImitate')}
+                      data={Object.values(UTLSImitate).map((utlsImitate) => ({
+                        label: utlsImitate,
+                        value: utlsImitate,
+                      }))}
+                      {...form.getInputProps('utlsImitate')}
+                    />
+                  )}
+                </Stack>
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
 
           <FormActions
             reset={() => {

--- a/src/components/ConfigFormModal.tsx
+++ b/src/components/ConfigFormModal.tsx
@@ -70,10 +70,12 @@ const schema = z.object({
 const InputList = <T extends z.infer<typeof schema>>({
   form,
   label,
+  description,
   fieldName,
   values,
 }: {
   label: string
+  description?: string
   fieldName: string
   values: string[]
   form: UseFormReturnType<T>
@@ -93,6 +95,8 @@ const InputList = <T extends z.infer<typeof schema>>({
           <IconPlus />
         </ActionIcon>
       </Group>
+
+      {description && <Input.Description>{description}</Input.Description>}
 
       {values.map((_, i) => (
         <Flex key={i} align="start" gap={6}>
@@ -264,55 +268,78 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
           </Stack>
 
           <Radio.Group label={t('dialMode')} {...form.getInputProps('dialMode')}>
-            <Group>
-              {Object.values(DialMode).map((dialMode) => (
-                <Radio key={dialMode} value={dialMode} label={dialMode} />
-              ))}
+            <Group mt="xs">
+              <Radio value={DialMode.ip} label={DialMode.ip} description={t('descriptions.dialMode.ip')} />
+              <Radio value={DialMode.domain} label={DialMode.domain} description={t('descriptions.dialMode.domain')} />
+              <Radio
+                value={DialMode.domainP}
+                label={DialMode.domainP}
+                description={t('descriptions.dialMode.domain+')}
+              />
+              <Radio
+                value={DialMode.domainPP}
+                label={DialMode.domainPP}
+                description={t('descriptions.dialMode.domain++')}
+              />
             </Group>
           </Radio.Group>
 
-          <SimpleGrid cols={3}>
-            <NumberInput
-              label={t('tproxyPort')}
-              withAsterisk
-              min={0}
-              max={65535}
-              {...form.getInputProps('tproxyPort')}
-            />
+          <NumberInput
+            label={t('tproxyPort')}
+            description={t('descriptions.tproxyPort')}
+            withAsterisk
+            min={0}
+            max={65535}
+            {...form.getInputProps('tproxyPort')}
+          />
 
-            <MultiSelect
-              label={t('wanInterface')}
-              withAsterisk
-              data={wanInterfacesData}
-              {...form.getInputProps('wanInterface')}
-            />
+          <Checkbox
+            label={t('tproxyPortProtect')}
+            description={t('descriptions.tproxyPortProtect')}
+            {...form.getInputProps('tproxyPortProtect', {
+              type: 'checkbox',
+            })}
+          />
 
-            <MultiSelect label={t('lanInterface')} data={lanInterfacesData} {...form.getInputProps('lanInterface')} />
-          </SimpleGrid>
+          <MultiSelect
+            label={t('wanInterface')}
+            description={t('descriptions.wanInterface')}
+            withAsterisk
+            data={wanInterfacesData}
+            {...form.getInputProps('wanInterface')}
+          />
 
-          <SimpleGrid cols={3}>
-            <NumberInput
-              label={`${t('checkInterval')} (s)`}
-              withAsterisk
-              {...form.getInputProps('checkIntervalSeconds')}
-            />
+          <MultiSelect
+            label={t('lanInterface')}
+            description={t('descriptions.lanInterface')}
+            data={lanInterfacesData}
+            {...form.getInputProps('lanInterface')}
+          />
 
-            <NumberInput
-              label={`${t('checkTolerance')} (ms)`}
-              withAsterisk
-              step={500}
-              {...form.getInputProps('checkToleranceMS')}
-            />
+          <NumberInput
+            label={`${t('checkInterval')} (s)`}
+            withAsterisk
+            {...form.getInputProps('checkIntervalSeconds')}
+          />
 
-            <NumberInput
-              label={`${t('sniffingTimeout')} (ms)`}
-              step={500}
-              {...form.getInputProps('sniffingTimeoutMS')}
-            />
-          </SimpleGrid>
+          <NumberInput
+            label={`${t('checkTolerance')} (ms)`}
+            description={t('descriptions.checkTolerance')}
+            withAsterisk
+            step={500}
+            {...form.getInputProps('checkToleranceMS')}
+          />
+
+          <NumberInput
+            label={`${t('sniffingTimeout')} (ms)`}
+            description={t('descriptions.sniffingTimeout')}
+            step={500}
+            {...form.getInputProps('sniffingTimeoutMS')}
+          />
 
           <Select
             label={t('tcpCheckHttpMethod')}
+            description={t('descriptions.tcpCheckHttpMethod')}
             data={Object.values(TcpCheckHttpMethod).map((tcpCheckHttpMethod) => ({
               label: tcpCheckHttpMethod,
               value: tcpCheckHttpMethod,
@@ -320,42 +347,46 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
             {...form.getInputProps('tcpCheckHttpMethod')}
           />
 
+          <InputList
+            form={form}
+            label={t('udpCheckDns')}
+            description={t('descriptions.udpCheckDns')}
+            fieldName="udpCheckDns"
+            values={form.values.udpCheckDns}
+          />
+
+          <InputList
+            form={form}
+            label={t('tcpCheckUrl')}
+            description={t('descriptions.tcpCheckUrl')}
+            fieldName="tcpCheckUrl"
+            values={form.values.tcpCheckUrl}
+          />
+
+          <Select
+            label={t('tlsImplementation')}
+            description={t('descriptions.tlsImplementation')}
+            data={Object.values(TLSImplementation).map((tlsImplementation) => ({
+              label: tlsImplementation,
+              value: tlsImplementation,
+            }))}
+            {...form.getInputProps('tlsImplementation')}
+          />
+
+          <Select
+            label={t('utlsImitate')}
+            description={t('descriptions.utlsImitate')}
+            data={Object.values(UTLSImitate).map((utlsImitate) => ({
+              label: utlsImitate,
+              value: utlsImitate,
+            }))}
+            {...form.getInputProps('utlsImitate')}
+          />
+
           <SimpleGrid cols={2}>
-            <InputList form={form} label={t('udpCheckDns')} fieldName="udpCheckDns" values={form.values.udpCheckDns} />
-
-            <InputList form={form} label={t('tcpCheckUrl')} fieldName="tcpCheckUrl" values={form.values.tcpCheckUrl} />
-          </SimpleGrid>
-
-          <SimpleGrid cols={2}>
-            <Select
-              label={t('tlsImplementation')}
-              data={Object.values(TLSImplementation).map((tlsImplementation) => ({
-                label: tlsImplementation,
-                value: tlsImplementation,
-              }))}
-              {...form.getInputProps('tlsImplementation')}
-            />
-
-            <Select
-              label={t('utlsImitate')}
-              data={Object.values(UTLSImitate).map((utlsImitate) => ({
-                label: utlsImitate,
-                value: utlsImitate,
-              }))}
-              {...form.getInputProps('utlsImitate')}
-            />
-          </SimpleGrid>
-
-          <SimpleGrid cols={2}>
-            <Checkbox
-              label={t('tproxyPortProtect')}
-              {...form.getInputProps('tproxyPortProtect', {
-                type: 'checkbox',
-              })}
-            />
-
             <Checkbox
               label={t('allowInsecure')}
+              description={t('descriptions.allowInsecure')}
               {...form.getInputProps('allowInsecure', {
                 type: 'checkbox',
               })}
@@ -363,6 +394,7 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
 
             <Checkbox
               label={t('autoConfigKernelParameter')}
+              description={t('descriptions.autoConfigKernelParameter')}
               {...form.getInputProps('autoConfigKernelParameter', {
                 type: 'checkbox',
               })}
@@ -370,6 +402,7 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
 
             <Checkbox
               label={t('disableWaitingNetwork')}
+              description={t('descriptions.disableWaitingNetwork')}
               {...form.getInputProps('disableWaitingNetwork', {
                 type: 'checkbox',
               })}

--- a/src/components/ConfigFormModal.tsx
+++ b/src/components/ConfigFormModal.tsx
@@ -272,7 +272,13 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
           </Radio.Group>
 
           <SimpleGrid cols={3}>
-            <NumberInput label={t('tproxyPort')} withAsterisk {...form.getInputProps('tproxyPort')} />
+            <NumberInput
+              label={t('tproxyPort')}
+              withAsterisk
+              min={0}
+              max={65535}
+              {...form.getInputProps('tproxyPort')}
+            />
 
             <MultiSelect
               label={t('wanInterface')}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -47,6 +47,28 @@
   "create account": "Create a new account",
   "dark mode": "Dark Mode",
   "debug": "debug",
+  "descriptions": {
+    "allowInsecure": "Allow insecure TLS certificates. It is not recommended to turn it on unless you have to.",
+    "autoConfigKernelParameter": "Automatically configure Linux kernel parameters like ip_forward and send_redirects.",
+    "checkTolerance": "Group will switch node only when new_latency <= old_latency - tolerance.",
+    "dialMode": {
+      "domain": "Dial proxy using the domain from sniffing. This will relieve DNS pollution problem to a great extent if have impure DNS environment. Generally, this mode brings faster proxy response time because proxy will re-resolve the domain in remote, thus get better IP result to connect. This policy does not impact routing. That is to say, domain rewrite will be after traffic split of routing and dae will not re-route it.",
+      "domain+": "Based on domain mode but do not check the reality of sniffed domain. It is useful for users whose DNS requests do not go through dae but want faster proxy response time. Notice that, if DNS requests do not go through dae, dae cannot split traffic by domain.",
+      "domain++": "Based on domain+ mode but force to re-route traffic using sniffed domain to partially recover domain based traffic split ability. It doesn't work for direct traffic and consumes more CPU resources.",
+      "ip": "Dial proxy using the IP from DNS directly. This allows your ipv4, ipv6 to choose the optimal path respectively, and makes the IP version requested by the application meet expectations. For example, if you use curl -4 ip.sb, you will request IPv4 via proxy and get a IPv4 echo. And curl -6 ip.sb will request IPv6. This may solve some wierd full-cone problem if your are be your node support that. Sniffing will be disabled in this mode."
+    },
+    "disableWaitingNetwork": "Disable waiting for network before pulling subscriptions.",
+    "lanInterface": "The LAN interface to bind. Use it if you want to proxy LAN.",
+    "sniffingTimeout": "Timeout to waiting for first data sending for sniffing. It is always 0 if dial_mode is ip. Set it higher is useful in high latency LAN network.",
+    "tcpCheckHttpMethod": "The HTTP request method to TCP Check HTTP Method. Use HEAD by default because some server implementations bypass accounting for this kind of traffic.",
+    "tcpCheckUrl": "Host of URL should have both IPv4 and IPv6 if you have double stack in local. First is URL, others are IP addresses if given. Considering traffic consumption, it is recommended to choose a site with anycast IP and less response.",
+    "tlsImplementation": "TLS implementation. tls is to use Go's crypto/tls. utls is to use uTLS, which can imitate browser's Client Hello.",
+    "tproxyPort": "Transparent Proxy Port to listen on. Valid range is 0 - 65535. It is NOT a HTTP/SOCKS port, and is just used by eBPF program. In normal case, you do not need to use it.",
+    "tproxyPortProtect": "Set it true to protect tproxy port from unsolicited traffic. Set it false to allow users to use self-managed iptables tproxy rules.",
+    "udpCheckDns": "This DNS will be used to check UDP connectivity of nodes. And if dns_upstream below contains tcp, it also be used to check TCP DNS connectivity of nodes. First is URL, others are IP addresses if given. This DNS should have both IPv4 and IPv6 if you have double stack in local.",
+    "utlsImitate": "The Client Hello ID for uTLS to imitate. This takes effect only if tls_implementation is utls.",
+    "wanInterface": "The WAN interface to bind. Use it if you want to proxy localhost."
+  },
   "dialMode": "Dial Mode",
   "disableWaitingNetwork": "Disable Waiting Network",
   "disconnected": "disconnected",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -44,6 +44,7 @@
     "removeConfirmDescription": "Are you sure you want to remove this?"
   },
   "connected": "connected",
+  "connecting options": "Connecting Options",
   "create account": "Create a new account",
   "dark mode": "Dark Mode",
   "debug": "debug",
@@ -83,6 +84,7 @@
   "global": "Global",
   "group": "Group",
   "info": "info",
+  "interface and kernel options": "Interface and Kernel Options",
   "ip": "ip",
   "lanInterface": "Lan Interface",
   "lanNatDirect": "lanNatDirect",
@@ -92,6 +94,7 @@
   "milliseconds": "ms",
   "name": "Name",
   "node": "Node",
+  "node connectivity check": "Node Connectivity Check",
   "notifications": {
     "login succeeded": "Login Succeeded",
     "success": "Success"
@@ -112,6 +115,7 @@
   "settings": "Settings",
   "setup endpoint": "Setup your backend (graphql) endpoint URL",
   "sniffingTimeout": "Sniffing Timeout",
+  "software options": "Software Options",
   "step": "Step",
   "subscription": "Subscription",
   "success": "Success",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -47,6 +47,28 @@
   "create account": "创建一个新的账户",
   "dark mode": "暗黑模式",
   "debug": "调试",
+  "descriptions": {
+    "allowInsecure": "允许使用不安全的TLS证书。除非迫不得已，否则不建议打开它。",
+    "autoConfigKernelParameter": "自动配置 Linux 内核参数，如 ip_forward（端口转发）和 send_redirects（发送重定向）。",
+    "checkTolerance": "只有当新的延迟 <= 旧的延迟 - 公差时，群组才会切换节点。",
+    "dialMode": {
+      "domain": "通过嗅探使用域名拨号代理。如果 DNS 环境不纯净，这将在很大程度上缓解 DNS 污染问题。通常，这种模式会带来更快的代理响应时间，因为代理会在远程重新解析域名，从而获得更好的 IP 连接结果。此策略不影响路由。也就是说，域重写将在流量拆分后进行路由，dae 不会对其进行重新路由。",
+      "domain+": "基于 domain 模式但不检查嗅探域名的真实性。对于那些 DNS 请求不通过 dae 但想要更快的代理响应时间的用户来说，这很有用。请注意，如果 DNS 请求不通过 dae，dae 就无法按域划分流量。",
+      "domain++": "基于 domain+ 模式，但强制使用嗅探域重新路由流量，以部分恢复基于域的流量拆分能力。它不适用于直接流量，并且会消耗更多的 CPU 资源。",
+      "ip": "直接使用来自 DNS 的 IP 拨号代理。这允许您的 ipv4、ipv6 分别选择最佳路径，并使应用程序请求的 IP 版本符合预期。例如，如果您使用 curl -4 ip.sb，您将通过代理请求 IPv4 并获得 IPv4 回显。curl -6 ip.sb 将请求 IPv6。如果你是你的节点支持的话，这可能会解决一些怪异的全锥形问题。在此模式下将禁用嗅探。"
+    },
+    "disableWaitingNetwork": "禁用在拉取订阅之前等待网络。",
+    "lanInterface": "要绑定的 LAN 接口。如果您想代理局域网，请使用它。",
+    "sniffingTimeout": "等待第一次发送数据以进行嗅探时超时。如果拨号模式为 ip，则始终为 0。将其设置得更高在高延迟局域网网络中很有用。",
+    "tcpCheckHttpMethod": "对 TCP 检测链接的 HTTP 请求方法。默认情况下使用 HEAD，因为某些服务器实现绕过了对此类流量的核算。",
+    "tcpCheckUrl": "如果您在本地有双堆栈，URL 的域名解析应该同时具有 IPv4 和 IPv6。第一个是 URL，其他是 IP 地址（如果给定的话）。考虑到流量消耗，建议选择具有 anycast IP 且响应较少的站点。",
+    "tlsImplementation": "TLS 实现。tls 是使用 Go 的 crypto/tls。utls 是使用 utls，它可以模仿浏览器的客户端 Hello。",
+    "tproxyPort": "要监听的透明代理端口。合法范围是 0 - 65535。它不是 HTTP/SOCKS 端口，仅由 eBPF 程序使用。在正常情况下，您不需要使用它。",
+    "tproxyPortProtect": "将其设置为 true 可保护透明代理端口免受未经请求的流量的影响。将其设置为 false 以允许用户使用自我管理的 iptables 透明代理规则。",
+    "udpCheckDns": "此 DNS 将用于检查节点的 UDP 连接。如果下面的 DNS 上游包含 TCP，它也可以用于检查节点的 TCP DNS 连接。第一个是 URL，其他是 IP地址（如果给定的话）。如果您在本地有双堆栈，则此 DNS 应该同时具有 IPv4 和 IPv6。",
+    "utlsImitate": "要模仿的 uTLS 的客户端 Hello ID。只有当 TLS 实现 为 utls 时，此操作才会生效。",
+    "wanInterface": "要绑定的 WAN 接口。如果您想代理本机，请使用它。"
+  },
   "dialMode": "拨号模式",
   "disableWaitingNetwork": "禁用网络等待",
   "disconnected": "未连接",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -44,6 +44,7 @@
     "removeConfirmDescription": "你确定要移除这个吗？"
   },
   "connected": "已连接",
+  "connecting options": "连接选项",
   "create account": "创建一个新的账户",
   "dark mode": "暗黑模式",
   "debug": "调试",
@@ -83,6 +84,7 @@
   "global": "全局",
   "group": "群组",
   "info": "信息",
+  "interface and kernel options": "接口及内核选项",
   "ip": "IP 地址",
   "lanInterface": "LAN 接口",
   "lanNatDirect": "LAN NAT 直连",
@@ -92,6 +94,7 @@
   "milliseconds": "毫秒",
   "name": "名字",
   "node": "节点",
+  "node connectivity check": "节点连通性检测",
   "notifications": {
     "login succeeded": "登录成功",
     "success": "成功"
@@ -112,6 +115,7 @@
   "settings": "设置",
   "setup endpoint": "设置你的后端（graphql）接口地址",
   "sniffingTimeout": "嗅探超时",
+  "software options": "软件选项",
   "step": "步骤",
   "subscription": "订阅",
   "success": "成功",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Previously, the tproxy port number input inside config modal has no upper and lower integer value limit, which doesnt align with the real-world TCP port number range (0 - 65535).

Also adds rich descriptive help texts for user inputs inside config form to help user understand what the config fields is doing

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelog

- feat(config): limit the tproxy port input range to `0 - 65535`
- feat(config): add descriptive help texts for user inputs

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
