### PR TITLE
feat: set `DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER` to true

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -109,7 +109,7 @@ export const DEFAULT_TCP_CHECK_URL = [
 export const DEFAULT_DIAL_MODE = DialMode.domain
 export const DEFAULT_TCP_CHECK_HTTP_METHOD = TcpCheckHttpMethod.HEAD
 export const DEFAULT_DISABLE_WAITING_NETWORK = false
-export const DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER = false
+export const DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER = true
 export const DEFAULT_TLS_IMPLEMENTATION = TLSImplementation.tls
 
 export const DEFAULT_CONFIG_WITH_INTERFACE = (interfaceName?: string): GlobalInput => ({
@@ -123,6 +123,7 @@ export const DEFAULT_CONFIG_WITH_INTERFACE = (interfaceName?: string): GlobalInp
   udpCheckDns: DEFAULT_UDP_CHECK_DNS,
   tcpCheckUrl: DEFAULT_TCP_CHECK_URL,
   dialMode: DEFAULT_DIAL_MODE,
+  autoConfigKernelParameter: DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER,
 })
 
 export const GET_LOG_LEVEL_STEPS = (t: TFunction) => [


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

set `DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER` to true, this can eliminate the requirement to do a manual sysctl.conf configuration by default.

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelog

- feat: set `DEFAULT_AUTO_CONFIG_KERNEL_PARAMETER` to true

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
