### PR TITLE
docs: migrate getting-started guide to /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# daed
-
 <h1 align="center">daed</h1>
 <p align="center" width="100%">
   <img width="100" src="public/logo.svg" />
-    <em>A collection of AWESOME Linux Applications and Tools for any of our community members</em>
+    <em>A modern web dashboard for [dae](https://github.com/v2raya/dae)</em>
 </p>
 
 <p align="center">
@@ -13,7 +11,6 @@
   <img src="https://custom-icon-badges.herokuapp.com/github/last-commit/daeuniverse/daed?logo=history&logoColor=white" alt="lastcommit" />
 </p>
 
-A modern web dashboard for [dae](https://github.com/v2raya/dae)
 
 ![preview](public/preview.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <h1 align="center">daed</h1>
 <p align="center" width="100%">
   <img width="100" src="public/logo.svg" />
-    <em>A modern web dashboard for [dae](https://github.com/v2raya/dae)</em>
+</p>
+<p align="center" width="100%">
+  <em>A modern web dashboard for dae</em>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # daed
 
+<h1 align="center">daed</h1>
 <p align="center" width="100%">
   <img width="100" src="public/logo.svg" />
+    <em>A collection of AWESOME Linux Applications and Tools for any of our community members</em>
 </p>
 
 <p align="center">
@@ -11,9 +13,7 @@
   <img src="https://custom-icon-badges.herokuapp.com/github/last-commit/daeuniverse/daed?logo=history&logoColor=white" alt="lastcommit" />
 </p>
 
-## What this project is for
-
-A Web Dashboard for [dae](https://github.com/v2raya/dae)
+A modern web dashboard for [dae](https://github.com/v2raya/dae)
 
 ![preview](public/preview.png)
 
@@ -24,78 +24,9 @@ A Web Dashboard for [dae](https://github.com/v2raya/dae)
 - [x] Light / Dark mode
 - [x] Mobile friendly
 
-### How to run and build this project
+## Getting Started
 
-> **Note**: This project is a standaone UI component that works together with [dae-wing](https://github.com/daeuniverse/dae-wing) (backend API server). This project cannot run alone without `dae-wing` since they are bundled as a software stack to interact with [dae](https://github.com/daeuniverse/dae) (core).
-
-#### Get started with dae-wing 
-
-Clone `dae-wing` to a remote or local linux environment
-
-```bash
-git clone https://github.com/daeuniverse/dae-wing.git
-
-cd dae-wing
-```
-
-Run the make script which will clone the dae repo to a specific folder relative to the working directory
-
-```bash
-make deps
-```
-
-Build the `dae-wing` binary using go build
-
-```bash
-go build .
-```
-
-Run the `dae-wing` binary we just built w/o `api-only` mode enabled
-
-```bash
-# ./dae-wing -c ./ --api-only
-./dae-wing -c ./
-```
-
-#### Get started with daed
-
-Clone this project to your development directory
-
-```sh
-git clone https://github.com/daeuniverse/daed.git
-
-cd daed
-```
-
-Install package dependencies using `pnpm`
-
-```sh
-pnpm install
-```
-
-> **Note**: We need to generate graphql type definitions and api bindings
-> Use environment variable `SCHEMA_PATH` to specify your schema endpoint
-> It can be a url starts with http(s) points to graphql endpoint or a static graphql schema file
-
-> **Important**: Optionally, append `-w` or `--watch` at the end of the command to watch upcoming changes
-
-```sh
-# SCHEMA_PATH=http(s)://example.com/graphql pnpm codegen
-# SCHEMA_PATH=http(s)://example.com/graphql.schema pnpm codegen
-
-SCHEMA_PATH=/path/to/SCHEMA_PATH pnpm codegen --watch
-```
-
-Start dev server
-
-```sh
-pnpm dev
-```
-
-If everything goes well, open your browser and navigate to http://localhost:5173
-
-Happy Hacking!
-
+Please refer to [Quick Start Guide](./docs/getting-started) to start using `daed` and `dae-wing` right away!
 
 ## Contribute to daed
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">daed</h1>
-<p align="center" width="100%">
+<p align="center">
   <img width="100" src="public/logo.svg" />
 </p>
-<p align="center" width="100%">
+<p align="center">
   <em>A modern web dashboard for dae</em>
 </p>
 
@@ -13,6 +13,7 @@
   <img src="https://custom-icon-badges.herokuapp.com/github/last-commit/daeuniverse/daed?logo=history&logoColor=white" alt="lastcommit" />
 </p>
 
+## Preview
 
 ![preview](public/preview.png)
 

--- a/docs/commit-msg-guide.md
+++ b/docs/commit-msg-guide.md
@@ -1,0 +1,81 @@
+# Semantic Commit Messages
+
+## The reasons for these conventions
+
+- automatic generating of the changelog
+- simple navigation through Git history (e.g. ignoring the style changes)
+
+See how a minor change to your commit message style can make you a better developer.
+
+## Format
+
+```
+`<type>(<scope>): <subject>`
+
+`<scope>` is optional
+```
+
+## Example
+
+```
+feat: add hat wobble
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+```
+
+Example `<type>` values:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change, e.g. dependencies upgrade)
+- `perf`: (perfomance improvement change, e.g. better concurrency performance)
+- `ci`: (updating CI configuration files and scripts e.g. `.gitHub/workflows/*.yml` )
+
+Example `<Scope>` values:
+
+- `init`
+- `runner`
+- `watcher`
+- `config`
+- `web-server`
+- `proxy`
+
+The `<scope>` can be empty (e.g. if the change is a global or difficult to assign to a single component), in which case the parentheses are omitted. In smaller projects such as Karma plugins, the `<scope>` is empty.
+
+## Message Subject (First Line)
+
+The first line cannot be longer than `72` characters and should be followed by a blank line. The type and scope should always be lowercase as shown below
+
+## Message Body
+
+use as in the `<subject>`, use the imperative, present tense: "change" not "changed" nor "changes". Message body should include motivation for the change and contrasts with previous behavior.
+
+## Message footer
+
+### Referencing issues
+
+Closed issues should be listed on a separate line in the footer prefixed with "Closes" keyword as the following:
+
+```
+Closes #234
+```
+
+or in the case of multiple issues:
+
+```
+Closes #123, #245, #992
+```
+
+## References
+
+- <https://www.conventionalcommits.org/>
+- <https://seesparkbox.com/foundry/semantic_commit_messages>
+- <http://karma-runner.github.io/1.0/dev/git-commit-msg.html>
+- <https://wadehuanglearning.blogspot.com/2019/05/commit-commit-commit-why-what-commit.html>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,73 @@
+# Quick Start Guide
+
+## How to run and build this project
+
+> **Note**: This project is a standaone UI component that works together with [dae-wing](https://github.com/daeuniverse/dae-wing) (backend API server). This project cannot run alone without `dae-wing` since they are bundled as a software stack to interact with [dae](https://github.com/daeuniverse/dae) (core).
+
+### Get started with dae-wing
+
+Clone `dae-wing` to a remote or local linux environment
+
+```bash
+git clone https://github.com/daeuniverse/dae-wing.git
+
+cd dae-wing
+```
+
+Run the make script which will clone the dae repo to a specific folder relative to the working directory
+
+```bash
+make deps
+```
+
+Build the `dae-wing` binary using go build
+
+```bash
+go build .
+```
+
+Run the `dae-wing` binary we just built w/o `api-only` mode enabled
+
+```bash
+# ./dae-wing -c ./ --api-only
+./dae-wing -c ./
+```
+
+### Get started with daed
+
+Clone this project to your development directory
+
+```sh
+git clone https://github.com/daeuniverse/daed.git
+
+cd daed
+```
+
+Install package dependencies using `pnpm`
+
+```sh
+pnpm install
+```
+
+> **Note**: We need to generate graphql type definitions and api bindings
+> Use environment variable `SCHEMA_PATH` to specify your schema endpoint
+> It can be a url starts with http(s) points to graphql endpoint or a static graphql schema file
+
+> **Important**: Optionally, append `-w` or `--watch` at the end of the command to watch upcoming changes
+
+```sh
+# SCHEMA_PATH=http(s)://example.com/graphql pnpm codegen
+# SCHEMA_PATH=http(s)://example.com/graphql.schema pnpm codegen
+
+SCHEMA_PATH=/path/to/SCHEMA_PATH pnpm codegen --watch
+```
+
+Start dev server
+
+```sh
+pnpm dev
+```
+
+If everything goes well, open your browser and navigate to http://localhost:5173
+
+Happy Hacking!


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- docs: migrate getting-started guide to ./docs/

### Preview

<img width="764" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/948c359d-c000-4ced-9553-c1f706d03918">


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA
