### PR TITLE
build: set independent app name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 OUTPUT ?= daed
+APPNAME ?= daed
+VERSION ?= 0.0.0.unknown
 
 .PHONY: submodules submodule
 
@@ -44,5 +46,5 @@ $(DAE_WING_READY): wing
 
 daed: submodule $(DAE_WING_READY) dist
 	cd wing && \
-	make OUTPUT=../$(OUTPUT) WEB_DIST=../dist bundle
+	make OUTPUT=../$(OUTPUT) APPNAME=$(APPNAME) WEB_DIST=../dist VERSION=$(VERSION) bundle
 ## End Bundle


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Customize the independent app name by setting the APPNAME environment variable.

See https://github.com/daeuniverse/dae-wing/pull/24

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #_[issue number]_
