### PR TITLE
chore: use go mod cache instead of go mod vendor

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Download artifact - full src
         uses: actions/download-artifact@v3
         with:
-          name: daed-full-src
+          name: daed-full-src.zip
           path: .
 
       - name: Extract daed-full-src.zip

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create full source ZIP archive and Signature
         run: |
-          zip -9vr daed-full-src.zip . -x .git/\*
+          zip -9vr daed-full-src.zip .
           FILE=./daed-full-src.zip
           DGST=$FILE.dgst
           md5sum        $FILE >>$DGST

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -115,15 +115,7 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-      - name: Download artifact - full src
-        uses: actions/download-artifact@v3
-        with:
-          name: daed-full-src.zip
-          path: .
-
-      - name: Extract daed-full-src.zip
-        run: |
-          unzip -o daed-full-src.zip
+      - uses: actions/checkout@v3
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
+          git submodule foreach --recursive touch $sm_path
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
           cd dae-core && go mod download -modcacherw && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
-          git submodule foreach --recursive 'touch $displaypath'
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
           cd dae-core && go mod download -modcacherw && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Extract daed-full-src.zip
         run: |
-          unzip -fo daed-full-src.zip
+          unzip -o daed-full-src.zip
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-      - name: Download artifact - web
+      - name: Download artifact - full src
         uses: actions/download-artifact@v3
         with:
           name: daed-full-src
@@ -135,7 +135,7 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           if [[ "$REF" == "refs/tags/v"* ]]; then
-            tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+            tag=${REF##*/}
             version=${tag}
             package_version="$(echo $tag | sed 's|v||g')"
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,7 @@ jobs:
 
       - name: Smoking test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
+        run: ./bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }} --version
 
       - name: Build Linux packages
         if: ${{ env.GOARM != '5' && env.GOARM != '6' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,10 @@ jobs:
           name: daed-full-src
           path: .
 
+      - name: Extract daed-full-src.zip
+        run: |
+          unzip -fo daed-full-src.zip
+
       - name: Get the version
         id: get_version
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,10 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
-          GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
-          find ./go-mod/ -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
+          export GOMODCACHE="${PWD}"/go-mod
+          go mod download -modcacherw
+          cd dae-core && go mod download -modcacherw && cd ..
+          find "$GOMODCACHE" -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
           sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
         working-directory: wing
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Download artifact - full src
         uses: actions/download-artifact@v3
         with:
-          name: daed-full-src
+          name: daed-full-src.zip
           path: .
 
       - name: Extract daed-full-src.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
-          git submodule foreach --recursive 'touch $sm_path'
+          git submodule foreach --recursive 'touch $displaypath'
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
           cd dae-core && go mod download -modcacherw && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
-          git submodule foreach --recursive touch $sm_path
+          git submodule foreach --recursive 'touch $sm_path'
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
           cd dae-core && go mod download -modcacherw && cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,11 @@ jobs:
           submodules: 'recursive'
 
       - name: Download wing vendor
-        run: go mod vendor
+        run: |
+          git submodule update --init --recursive
+          GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
+          find ./go-mod/ -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
+          sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
         working-directory: wing
 
       - name: Create full source ZIP archive and Signature

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,11 +127,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: daed-full-src
-          path: .daed
-
-      - name: Move files out of .daed
-        run: |
-          mv .daed/* .
+          path: .
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: daed-full-src
-          path: .
+          path: .daed
+
+      - name: Move files out of .daed
+        run: |
+          mv .daed/* .
 
       - name: Get the version
         id: get_version
@@ -137,7 +141,7 @@ jobs:
           if [[ "$REF" == "refs/tags/v"* ]]; then
             tag=${REF##*/}
             version=${tag}
-            package_version="$(echo $tag | sed 's|v||g')"
+            package_version="${tag:1}"
           else
             date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
             count=$(git rev-list --count HEAD)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           path: dist
 
   build-bundle:
-    needs: build-web
+    needs: [build-web, full-src]
     runs-on: ubuntu-latest
 
     strategy:
@@ -123,9 +123,11 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Download artifact - web
+        uses: actions/download-artifact@v3
         with:
-          fetch-depth: 0
+          name: daed-full-src
+          path: .
 
       - name: Get the version
         id: get_version
@@ -288,7 +290,7 @@ jobs:
               shasum -a 512 $package >> $package.dgst
           done
           ls -lh | grep -E ".deb|.pkg.tar.zst|.rpm|.zip"
-          
+
       - name: Delete current release assets
         uses: 8Mi-Tech/delete-release-assets-action@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           path: dist
 
   build-bundle:
-    needs: [build-web, full-src]
+    needs: [build-web]
     runs-on: ubuntu-latest
 
     strategy:
@@ -123,15 +123,7 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-      - name: Download artifact - full src
-        uses: actions/download-artifact@v3
-        with:
-          name: daed-full-src.zip
-          path: .
-
-      - name: Extract daed-full-src.zip
-        run: |
-          unzip -o daed-full-src.zip
+      - uses: actions/checkout@v3
 
       - name: Get the version
         id: get_version

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ dist-ssr
 *.sw?
 
 # Make
-.gitmodules.d.mk
 daed

--- a/.gitmodules.d.mk
+++ b/.gitmodules.d.mk
@@ -1,0 +1,1 @@
+submodule_paths=wing

--- a/.gitmodules.d.mk
+++ b/.gitmodules.d.mk
@@ -1,1 +1,1 @@
-submodule_paths=wing
+submodule_ready=wing/.git

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 ## Begin Git Submodules
 .gitmodules.d.mk: .gitmodules
 	@set -e && \
-	submodules=$$(grep '\[submodule "' .gitmodules | cut -d'"' -f2 | tr '\n' ' ') && \
+	submodules=$$(grep '\[submodule "' .gitmodules | cut -d'"' -f2 | tr '\n' ' ' | tr ' \n' '\n') && \
 	echo "submodule_paths=$${submodules}" > $@
 
 -include .gitmodules.d.mk
@@ -38,7 +38,7 @@ dist: package.json pnpm-lock.yaml
 ## End Web
 
 ## Begin Bundle
-DAE_WING_READY=wing/vendor/github.com/daeuniverse/dae/control/headers wing/graphql/service/config/global/generated_resolver.go
+DAE_WING_READY=wing/graphql/service/config/global/generated_resolver.go
 
 $(DAE_WING_READY): wing
 	cd wing && \

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,19 @@ clean:
 	rm -rf dist && rm -f daed
 
 ## Begin Git Submodules
-.gitmodules.d.mk: .gitmodules
+.gitmodules.d.mk: .gitmodules Makefile
 	@set -e && \
 	submodules=$$(grep '\[submodule "' .gitmodules | cut -d'"' -f2 | tr '\n' ' ' | tr ' \n' '\n') && \
-	echo "submodule_paths=$${submodules}" > $@
+	echo "submodule_ready=$${submodules}/.git" > $@
 
 -include .gitmodules.d.mk
 
-$(submodule_paths): .gitmodules.d.mk
-	git submodule update --init --recursive -- $@ && \
+$(submodule_ready): .gitmodules.d.mk
+	git submodule update --init --recursive -- "$$(dirname $@)" && \
 	touch $@
 
-submodule submodules: $(submodule_paths)
-	@if [ -z "$(submodule_paths)" ]; then \
+submodule submodules: $(submodule_ready)
+	@if [ -z "$(submodule_ready)" ]; then \
 		rm -f .gitmodules.d.mk; \
 		echo "Failed to generate submodules list. Please try again."; \
 		exit 1; \
@@ -42,9 +42,11 @@ DAE_WING_READY=wing/graphql/service/config/global/generated_resolver.go
 
 $(DAE_WING_READY): wing
 	cd wing && \
-	make deps
+	$(MAKE) deps && \
+	cd .. && \
+	touch $@
 
 daed: submodule $(DAE_WING_READY) dist
 	cd wing && \
-	make OUTPUT=../$(OUTPUT) APPNAME=$(APPNAME) WEB_DIST=../dist VERSION=$(VERSION) bundle
+	$(MAKE) OUTPUT=../$(OUTPUT) APPNAME=$(APPNAME) WEB_DIST=../dist VERSION=$(VERSION) bundle
 ## End Bundle


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Use `go mod cache` for fuller mod support.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

