### PR TITLE
fix(sync-upstream-docs): do not use ref in checkout action

### DIFF
--- a/.github/workflows/sync-upstream-source.yml
+++ b/.github/workflows/sync-upstream-source.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-          ref: ${{ inputs.pr-base-branch }}
+          # ref: ${{ inputs.pr-base-branch }}
+          # let's leave ref here for future testing
 
       - name: Sync dae-wing upstream
         run: |


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA
