### PR TITLE
ci: separate release build from main_stream build

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,9 +1,12 @@
-name: Publish Release
-run-name: Publish release ${{ github.ref_name }} by @${{ github.actor }}
+name: Publish Pre-release
+run-name: Publish prerelease ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-  # will come back add add input here
+  push:
+    tags:
+      - 'v*.*.*rc'
+      - 'v*.*.*p*'
 
 jobs:
   checkout-full-src:
@@ -219,8 +222,7 @@ jobs:
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.rpm
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.pkg.tar.zst
 
-  upload-release:
-    if: github.event_name == 'release'
+  upload-prerelease:
     needs: [checkout-full-src, build-bundle]
     runs-on: ubuntu-latest
     steps:
@@ -252,14 +254,22 @@ jobs:
           echo "Show files are going to upload..."
           ls -lh | grep -E ".deb|.pkg.tar.zst|.rpm|.zip"
 
-      - name: Upload Release
+      - name: Delete current release assets
+        uses: 8Mi-Tech/delete-release-assets-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          deleteOnlyFromDrafts: false
+
+      - name: Upload Prerelease
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
           files: |
             *zip
             *pkg.tar.zst
             *deb
             *rpm
             *dgst
+          prerelease: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
-name: Build
+name: Release
+run-name: Publish prerelease ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    tags:
+      - 'v*.*.*'
 
 jobs:
   checkout-full-src:
@@ -218,3 +220,100 @@ jobs:
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.deb
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.rpm
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.pkg.tar.zst
+
+  upload-release:
+    if: github.event_name == 'release'
+    needs: [checkout-full-src, build-bundle]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: release/
+
+      - name: Prepare files for upload
+        run: |
+          cp release/*/*.deb ./
+          cp release/*/*.rpm ./
+          cp release/*/*.pkg.tar.zst ./
+          cp release/*/*.zip ./
+          pushd release
+          zip -9vr ../web.zip web/*
+          for zip_file in $(ls | grep -E "^daed-linux*");do
+              pushd $zip_file
+              zip -9r ../../"$zip_file".zip ./*
+              popd
+          done
+          popd
+          for package in $(ls | grep -E ".deb|.pkg.tar.zst|.rpm|.zip");do
+              echo "$(md5sum $package)""  md5" >> $package.dgst
+              echo "$(shasum -a 1 $package)""  sha1" >> $package.dgst
+              echo "$(shasum -a 256 $package)""  sha256" >> $package.dgst
+              echo "$(shasum -a 512 $package)""  sha512" >> $package.dgst
+          done
+          echo "Show files are going to upload..."
+          ls -lh | grep -E ".deb|.pkg.tar.zst|.rpm|.zip"
+
+      - name: Upload Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          files: |
+            *zip
+            *pkg.tar.zst
+            *deb
+            *rpm
+            *dgst
+          generate_release_notes: true
+
+  upload-prerelease:
+    needs: [checkout-full-src, build-bundle]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: release/
+
+      - name: Prepare files for upload
+        run: |
+          cp release/*/*.deb ./
+          cp release/*/*.rpm ./
+          cp release/*/*.pkg.tar.zst ./
+          cp release/*/*.zip ./
+          pushd release
+          zip -9vr ../web.zip web/*
+          for zip_file in $(ls | grep -E "^daed-linux*");do
+              pushd $zip_file
+              zip -9r ../../"$zip_file".zip ./*
+              popd
+          done
+          popd
+          for package in $(ls | grep -E ".deb|.pkg.tar.zst|.rpm|.zip");do
+              echo "$(md5sum $package)""  md5" >> $package.dgst
+              echo "$(shasum -a 1 $package)""  sha1" >> $package.dgst
+              echo "$(shasum -a 256 $package)""  sha256" >> $package.dgst
+              echo "$(shasum -a 512 $package)""  sha512" >> $package.dgst
+          done
+          echo "Show files are going to upload..."
+          ls -lh | grep -E ".deb|.pkg.tar.zst|.rpm|.zip"
+
+      - name: Delete current release assets
+        uses: 8Mi-Tech/delete-release-assets-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          deleteOnlyFromDrafts: false
+
+      - name: Upload Prerelease
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            *zip
+            *pkg.tar.zst
+            *deb
+            *rpm
+            *dgst
+          prerelease: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Publish Release
-run-name: Publish release ${{ github.ref_name }} by @${{ github.actor }}
+# run-name: Publish release ${{ github.ref_name }} by @${{ github.actor }}
+# ${{ github.ref }} replaced by ==> ${{ inputs.x }}; x is undetermined
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Getting ready for initial release. By default, the release workflow is designed to be triggered ONLY by `push.tag` event. The reason why I propose to do it in such a way is that it may better fit into the `automatic release` cycle in the future.

> **Note**: Instead of us manually push a release tag, @daebot will do it for us in the `next` release cycle - already planned in our roadmap.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- ci: separate release build from main_stream build

### Test result

https://github.com/daeuniverse/daed-1/actions/runs/5304376937

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA.
