### PR TITLE
ci(build-nightly): add fetch-depth: 0

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -135,6 +135,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get the version
         id: get_version


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests, this PR specify fetch-depth: 0 for checkout step before getting version info from git history

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- ci(build-nightly): add fetch-depth: 0

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
