### PR TITLE
ci(release): retrieve release tag (version) from dispatch inputs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -272,4 +272,3 @@ jobs:
             *rpm
             *dgst
           prerelease: true
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,4 +256,3 @@ jobs:
             *deb
             *rpm
             *dgst
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Publish Release
-# run-name: Publish release ${{ github.ref_name }} by @${{ github.actor }}
-# ${{ github.ref }} replaced by ==> ${{ inputs.x }}; x is undetermined
+run-name: Publish release ${{ inputs.tag }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-  # will come back add add input here
+    inputs:
+      tag:
+        type: string
+        required: true
 
 jobs:
   checkout-full-src:
@@ -129,19 +131,11 @@ jobs:
       - name: Get the version
         id: get_version
         env:
-          REF: ${{ github.ref }}
+          REF: ${{ inputs.tag }}
         run: |
-          if [[ "$REF" == "refs/tags/v"* ]]; then
-            tag=${REF##*/}
-            version=${tag}
-            package_version="${tag:1}"
-          else
-            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
-            count=$(git rev-list --count HEAD)
-            commit=$(git rev-parse --short HEAD)
-            version="unstable-$date.r${count}.$commit"
-            package_version="$date.r${count}.$commit"
-          fi
+          tag=${REF}
+          version=${tag}
+          package_version="${tag:1}"
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "PACKAGE_VERSION=$package_version" >> $GITHUB_OUTPUT
@@ -221,7 +215,6 @@ jobs:
             installer-${{ steps.get_filename.outputs.BUNDLE_NAME }}.pkg.tar.zst
 
   upload-release:
-    if: github.event_name == 'release'
     needs: [checkout-full-src, build-bundle]
     runs-on: ubuntu-latest
     steps:
@@ -256,7 +249,7 @@ jobs:
       - name: Upload Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ inputs.tag }}
           files: |
             *zip
             *pkg.tar.zst


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- ci(release): retrieve release tag (version) from dispatch inputs
- ci(release): do NOT generate release notes on the fly

### Test Result

https://github.com/daeuniverse/daed-1/actions/runs/5311591937

<img width="640" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/5ea88188-e954-4895-a116-81c5c6ecd5e5">

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA