### PR TITLE
ci: add sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,42 @@
+name: Synchronize Upstream
+
+on:
+  workflow_dispatch:
+    inputs:
+      wing-head:
+        type: string
+        required: true
+        default: main
+      wing-sync-message:
+        type: string
+        required: true
+        default: 'chore(sync): upgrade dae-wing'
+      pr-branch:
+        type: string
+        required: true
+        default: sync-upstream
+
+jobs:
+  sync-wing:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.wing-head }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          ref: main
+
+      - name: Sync dae-wing upstream
+        run: |
+          git checkout origin/${{ inputs.wing-head }}
+        working-directory: wing
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "daebot"
+          git config user.email "daebot@v2raya.org"
+          git checkout -b ${{ inputs.pr-branch }}
+          git add .
+          git commit -m "${{ inputs.wing-sync-message }}" --no-verify
+          git push -u origin ${{ inputs.pr-branch }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

## Background

<!--- Why is this change required? What problem does it solve? -->

Add `sync-upstream` workflow back, but this time, let's do NOT add the ~~broken~~ PR create action. Instead, let @daebot automate the PR creation for us.

## Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

## Full changelog

- ci: add sync-upstream workflow

## Mock

Try to reproduce the test scenario as much as I could...

### Expected Outcome

- [x] The `sync-upstream` workflow in `daed-1` is kicked off
- [x] `daebot` creates a pull_request after the workflow run has been completed

### Reproduction

1.1 checkout to a specific history commit in `dae-wing` submodule

<img width="1061" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/8d4121b9-09af-465b-bcfe-aae5986655ef">

<img width="865" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/0f21df2b-0d5f-44cd-bd1d-c096da9e125f">

<img width="711" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/69500285-ec8a-4f37-9090-3d6d372a85f3">

1.2 kick off the `sync-upstream` workflow by pushing a commit to `ci-bot-experiment` origin/main

> **Note**: In the production case, we should use `dae-wing`.

<img width="1740" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/9eac5323-f4cc-4c46-8623-ae56878d235b">

1.3 create a PR on the fly

<img width="1727" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/689aa917-11fb-4213-b7c0-1fe4540e8e66">

<img width="984" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/4731c258-573e-47bb-b36e-af7949760844">

<img width="752" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/afb29476-a4b2-4f64-bf54-8e32205f1d05">


## Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA
