### PR TITLE
fix(subscription): loading indicator of update

### DIFF
--- a/src/components/DraggableSubscriptionNodeBadge.tsx
+++ b/src/components/DraggableSubscriptionNodeBadge.tsx
@@ -1,5 +1,5 @@
 import { useDraggable } from '@dnd-kit/core'
-import { Badge, Text } from '@mantine/core'
+import { Badge, Text, Tooltip } from '@mantine/core'
 
 import { DraggableResourceType } from '~/constants'
 
@@ -8,11 +8,13 @@ export const DraggableSubscriptionNodeBadge = ({
   subscriptionID,
   name,
   dragDisabled,
+  children,
 }: {
   id: string
   subscriptionID: string
   name: string
   dragDisabled?: boolean
+  children?: React.ReactNode
 }) => {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id,
@@ -24,8 +26,16 @@ export const DraggableSubscriptionNodeBadge = ({
   })
 
   return (
-    <Badge ref={setNodeRef} style={{ cursor: 'grab', zIndex: isDragging ? 10 : 0 }} {...listeners} {...attributes}>
-      <Text truncate>{name}</Text>
-    </Badge>
+    <Tooltip fz="xs" label={children} withArrow>
+      <Badge
+        ref={setNodeRef}
+        style={{ cursor: 'grab', zIndex: isDragging ? 10 : 0 }}
+        opacity={isDragging ? 0.5 : undefined}
+        {...listeners}
+        {...attributes}
+      >
+        <Text truncate>{name}</Text>
+      </Badge>
+    </Tooltip>
   )
 }

--- a/src/components/UpdateSubscriptionAction.tsx
+++ b/src/components/UpdateSubscriptionAction.tsx
@@ -1,0 +1,18 @@
+import { ActionIcon } from '@mantine/core'
+import { IconDownload } from '@tabler/icons-react'
+
+import { useUpdateSubscriptionsMutation } from '~/apis'
+
+export const UpdateSubscriptionAction = ({ id }: { id: string }) => {
+  const updateSubscriptionsMutation = useUpdateSubscriptionsMutation()
+
+  return (
+    <ActionIcon
+      loading={updateSubscriptionsMutation.isLoading}
+      size="sm"
+      onClick={() => updateSubscriptionsMutation.mutate([id])}
+    >
+      <IconDownload />
+    </ActionIcon>
+  )
+}

--- a/src/pages/Orchestrate.tsx
+++ b/src/pages/Orchestrate.tsx
@@ -22,7 +22,6 @@ import { useStore } from '@nanostores/react'
 import {
   IconCloud,
   IconCloudComputing,
-  IconDownload,
   IconEdit,
   IconForms,
   IconMap,
@@ -64,7 +63,6 @@ import {
   useSubscriptionsQuery,
   useUpdateDNSMutation,
   useUpdateRoutingMutation,
-  useUpdateSubscriptionsMutation,
 } from '~/apis'
 import { ConfigFormDrawer, ConfigFormDrawerRef } from '~/components/ConfigFormModal'
 import { DraggableResourceCard } from '~/components/DraggableResourceCard'
@@ -77,6 +75,7 @@ import { RenameFormModal, RenameFormModalRef } from '~/components/RenameFormModa
 import { Section } from '~/components/Section'
 import { SimpleCard } from '~/components/SimpleCard'
 import { SortableResourceBadge } from '~/components/SortableResourceBadge'
+import { UpdateSubscriptionAction } from '~/components/UpdateSubscriptionAction'
 import { DraggableResourceType, GET_LOG_LEVEL_STEPS, RuleType } from '~/constants'
 import { defaultResourcesAtom } from '~/store'
 import { deriveTime } from '~/utils'
@@ -175,7 +174,6 @@ export const OrchestratePage = () => {
   const createRoutingMutation = useCreateRoutingMutation()
   const importNodesMutation = useImportNodesMutation()
   const importSubscriptionsMutation = useImportSubscriptionsMutation()
-  const updateSubscriptionsMutation = useUpdateSubscriptionsMutation()
 
   const renameFormModalRef = useRef<RenameFormModalRef>(null)
   const renameConfigMutation = useRenameConfigMutation()
@@ -587,15 +585,7 @@ export const OrchestratePage = () => {
                   id={subscriptionID}
                   type={DraggableResourceType.subscription}
                   name={tag || link}
-                  actions={
-                    <ActionIcon
-                      loading={updateSubscriptionsMutation.isLoading}
-                      size="sm"
-                      onClick={() => updateSubscriptionsMutation.mutate([subscriptionID])}
-                    >
-                      <IconDownload />
-                    </ActionIcon>
-                  }
+                  actions={<UpdateSubscriptionAction id={subscriptionID} />}
                   onRemove={() => removeSubscriptionsMutation.mutate([subscriptionID])}
                 >
                   <Text fw={600}>{dayjs(updatedAt).format('YYYY-MM-DD HH:mm:ss')}</Text>
@@ -628,7 +618,9 @@ export const OrchestratePage = () => {
                               subscriptionID={subscriptionID}
                               name={name}
                               id={id}
-                            />
+                            >
+                              {name}
+                            </DraggableSubscriptionNodeBadge>
                           ))}
                         </Group>
                       </Accordion.Panel>


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Previously, every loading indicators will be spining when one of the subscriptions is updating, this PR fixes that.

Now it should be showing only on individual subscription updating.

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- fix(subscription): loading indicator of update should show on individual subscription

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
