### PR TITLE
fix: default googledns add tcp

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -154,7 +154,7 @@ fallback: ${DEFAULT_GROUP_NAME}
 export const DEFAULT_DNS = `
 upstream {
   alidns: 'udp://223.5.5.5:53'
-  googledns: 'udp://8.8.8.8:53'
+  googledns: 'tcp+udp://8.8.8.8:53'
 }
 routing {
   request {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

This PR adds tcp method to default googledns url

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- fix: default googledns add tcp

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
