### PR TITLE
fix(group): refresh after remove nodes/subs

### DIFF
--- a/src/apis/mutation.ts
+++ b/src/apis/mutation.ts
@@ -682,6 +682,7 @@ export const useRemoveNodesMutation = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY_NODE })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_GROUP })
     },
   })
 }
@@ -769,6 +770,7 @@ export const useRemoveSubscriptionsMutation = () => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY_SUBSCRIPTION })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_GROUP })
     },
   })
 }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

![telegram-cloud-photo-size-1-4947389630630702031-y](https://github.com/daeuniverse/daed/assets/17328586/90c47416-4b06-4ff9-82ab-a9543f768b3d)

When user remove a node or subscription (specifically, not within a group), if it's currently referenced by a group, the group still has that present. This PR fixes it by refreshing group list after removing nodes or subscriptions.

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- fix(group): refresh after remove nodes/subs

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
