### PR TITLE
feat: show node protocol in card title

### DIFF
--- a/src/components/DraggableResourceCard.tsx
+++ b/src/components/DraggableResourceCard.tsx
@@ -2,6 +2,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { ActionIcon, Badge, Card, Group, Text } from '@mantine/core'
 import { modals } from '@mantine/modals'
 import { IconTrash } from '@tabler/icons-react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { DraggableResourceType } from '~/constants'
@@ -12,6 +13,7 @@ export const DraggableResourceCard = ({
   subscriptionID,
   type,
   name,
+  leftSection,
   onRemove,
   actions,
   children,
@@ -20,7 +22,8 @@ export const DraggableResourceCard = ({
   nodeID?: string
   subscriptionID?: string
   type: DraggableResourceType
-  name: string
+  name: React.ReactNode
+  leftSection?: React.ReactNode
   onRemove: () => void
   actions?: React.ReactNode
   children: React.ReactNode
@@ -39,7 +42,9 @@ export const DraggableResourceCard = ({
       }}
     >
       <Card.Section withBorder p="sm">
-        <Group position="apart">
+        <Group position="apart" spacing="xs">
+          {leftSection}
+
           <Badge
             size="lg"
             style={{

--- a/src/pages/Orchestrate/Node.tsx
+++ b/src/pages/Orchestrate/Node.tsx
@@ -27,13 +27,17 @@ export const NodeResource = () => {
           id={`node-${id}`}
           nodeID={id}
           type={DraggableResourceType.node}
-          name={tag!}
+          name={tag}
+          leftSection={
+            <Text fz="xs" fw={600}>
+              {protocol}
+            </Text>
+          }
           onRemove={() => removeNodesMutation.mutate([id])}
         >
           <Text fw={600} color={theme.primaryColor}>
             {name}
           </Text>
-          <Text fw={600}>{protocol}</Text>
 
           <Spoiler
             maxHeight={0}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

This PR adds a new feature, change the node protocol display, instead of card body, show the node protocol in card title, like the screenshot shows

<img width="391" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/24cf027b-c56f-49cc-b7db-05c2e5db71b4">

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat: show node protocol in card title

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
