### PR TITLE
feat: render qrcode in canvas to allow user to save image

### DIFF
--- a/src/components/QRCodeModal.tsx
+++ b/src/components/QRCodeModal.tsx
@@ -1,5 +1,5 @@
 import { Center, Modal } from '@mantine/core'
-import { QRCodeSVG } from 'qrcode.react'
+import { QRCodeCanvas } from 'qrcode.react'
 import { forwardRef, useImperativeHandle, useState } from 'react'
 
 type Props = {
@@ -26,7 +26,7 @@ export const QRCodeModal = forwardRef(({ opened, onClose }: { opened: boolean; o
   return (
     <Modal opened={opened} onClose={onClose} title={props.name}>
       <Center>
-        <QRCodeSVG size={320} value={props.link} />
+        <QRCodeCanvas size={320} value={props.link} />
       </Center>
     </Modal>
   )

--- a/src/components/UpdateSubscriptionAction.tsx
+++ b/src/components/UpdateSubscriptionAction.tsx
@@ -9,7 +9,7 @@ export const UpdateSubscriptionAction = ({ id, loading }: { id: string; loading?
   return (
     <ActionIcon
       loading={loading || updateSubscriptionsMutation.isLoading}
-      size="sm"
+      size="xs"
       onClick={() => updateSubscriptionsMutation.mutate([id])}
     >
       <IconDownload />

--- a/src/pages/Orchestrate/Node.tsx
+++ b/src/pages/Orchestrate/Node.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { useImportNodesMutation, useNodesQuery, useRemoveNodesMutation } from '~/apis'
 import { DraggableResourceCard } from '~/components/DraggableResourceCard'
 import { ImportResourceFormModal } from '~/components/ImportResourceFormModal'
-import { QRCodeModal, QRCodeModalRef } from '~/components/NodeQRCodeModal'
+import { QRCodeModal, QRCodeModalRef } from '~/components/QRCodeModal'
 import { Section } from '~/components/Section'
 import { DraggableResourceType } from '~/constants'
 

--- a/src/pages/Orchestrate/Subscription.tsx
+++ b/src/pages/Orchestrate/Subscription.tsx
@@ -14,7 +14,7 @@ import {
 import { DraggableResourceBadge } from '~/components/DraggableResourceBadge'
 import { DraggableResourceCard } from '~/components/DraggableResourceCard'
 import { ImportResourceFormModal } from '~/components/ImportResourceFormModal'
-import { QRCodeModal, QRCodeModalRef } from '~/components/NodeQRCodeModal'
+import { QRCodeModal, QRCodeModalRef } from '~/components/QRCodeModal'
 import { Section } from '~/components/Section'
 import { UpdateSubscriptionAction } from '~/components/UpdateSubscriptionAction'
 import { DraggableResourceType } from '~/constants'


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="636" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/87f72c75-109b-45af-b50e-575b488ea3ab">

This PR adds a new feature, render qrcode in canvas to allow user to save image

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat: render qrcode in canvas to allow user to save image

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
