### PR TITLE
feat: use theme `github` as default monaco editor light theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "immer": "^10.0.2",
     "lint-staged": "^13.2.2",
     "mantine-datatable": "^2.6.4",
+    "monaco-editor": "^0.39.0",
+    "monaco-themes": "^0.4.4",
     "nanostores": "^0.9.2",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,12 @@ dependencies:
   mantine-datatable:
     specifier: ^2.6.4
     version: 2.6.4(@mantine/core@6.0.14)(@mantine/hooks@6.0.14)(react@18.2.0)
+  monaco-editor:
+    specifier: ^0.39.0
+    version: 0.39.0
+  monaco-themes:
+    specifier: ^0.4.4
+    version: 0.4.4
   nanostores:
     specifier: ^0.9.2
     version: 0.9.2
@@ -5217,6 +5223,10 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: false
 
+  /fast-plist@0.1.3:
+    resolution: {integrity: sha512-d9cEfo/WcOezgPLAC/8t8wGb6YOD6JTCPMw2QcG2nAdFmyY+9rTUizCTaGjIZAloWENTEUMAPpkUAIJJJ0i96A==}
+    dev: false
+
   /fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
     dependencies:
@@ -6615,6 +6625,12 @@ packages:
 
   /monaco-editor@0.39.0:
     resolution: {integrity: sha512-zhbZ2Nx93tLR8aJmL2zI1mhJpsl87HMebNBM6R8z4pLfs8pj604pIVIVwyF1TivcfNtIPpMXL+nb3DsBmE/x6Q==}
+    dev: false
+
+  /monaco-themes@0.4.4:
+    resolution: {integrity: sha512-Hbb9pvRrpSi0rZezcB/IOdQnpx10o55Lx4zFdRAAVpFMa1HP7FgaqEZdKffb4ovd90fETCixeFO9JPYFMAq+TQ==}
+    dependencies:
+      fast-plist: 0.1.3
     dev: false
 
   /ms@2.1.2:

--- a/src/components/PlainTextFormModal.tsx
+++ b/src/components/PlainTextFormModal.tsx
@@ -6,7 +6,7 @@ import { forwardRef, useImperativeHandle, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { z } from 'zod'
 
-import { EDITOR_OPTIONS } from '~/constants'
+import { EDITOR_OPTIONS, EDITOR_THEME_DARK, EDITOR_THEME_LIGHT } from '~/constants'
 import { colorSchemeAtom } from '~/store'
 
 import { FormActions } from './FormActions'
@@ -78,7 +78,7 @@ export const PlainTextFormModal = forwardRef(
             <Stack spacing={4}>
               <Editor
                 height={320}
-                theme={colorScheme === 'dark' ? 'vs-dark' : 'light'}
+                theme={colorScheme === 'dark' ? EDITOR_THEME_DARK : EDITOR_THEME_LIGHT}
                 options={EDITOR_OPTIONS}
                 value={form.values.text}
                 onChange={(value) => form.setFieldValue('text', value || '')}

--- a/src/components/PlainTextFormModal.tsx
+++ b/src/components/PlainTextFormModal.tsx
@@ -1,4 +1,4 @@
-import { Input, Modal, Stack, TextInput } from '@mantine/core'
+import { Box, Input, Modal, Stack, TextInput } from '@mantine/core'
 import { UseFormReturnType, useForm, zodResolver } from '@mantine/form'
 import { Editor } from '@monaco-editor/react'
 import { useStore } from '@nanostores/react'
@@ -76,13 +76,20 @@ export const PlainTextFormModal = forwardRef(
             <TextInput label={t('name')} withAsterisk {...form.getInputProps('name')} disabled={!!editingID} />
 
             <Stack spacing={4}>
-              <Editor
-                height={320}
-                theme={colorScheme === 'dark' ? EDITOR_THEME_DARK : EDITOR_THEME_LIGHT}
-                options={EDITOR_OPTIONS}
-                value={form.values.text}
-                onChange={(value) => form.setFieldValue('text', value || '')}
-              />
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  borderRadius: 4,
+                }}
+              >
+                <Editor
+                  height={320}
+                  theme={colorScheme === 'dark' ? EDITOR_THEME_DARK : EDITOR_THEME_LIGHT}
+                  options={EDITOR_OPTIONS}
+                  value={form.values.text}
+                  onChange={(value) => form.setFieldValue('text', value || '')}
+                />
+              </Box>
 
               {form.errors['text'] && <Input.Error>{form.errors['text']}</Input.Error>}
             </Stack>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -187,6 +187,9 @@ export enum RuleType {
   group = 'group',
 }
 
+export const EDITOR_THEME_DARK = 'vs-dark'
+export const EDITOR_THEME_LIGHT = 'github'
+
 export const EDITOR_OPTIONS: EditorProps['options'] = {
   fontSize: 14,
   fontWeight: 'bold',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,63 @@
+/* eslint-disable import/default */
 import '~/index.css'
 
+import { loader } from '@monaco-editor/react'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
+import * as monaco from 'monaco-editor'
+import { editor } from 'monaco-editor'
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import ReactDOM from 'react-dom/client'
 
 import { App } from '~/App'
 import { i18nInit } from '~/i18n'
 
+import { EDITOR_THEME_LIGHT } from './constants'
+
 dayjs.extend(duration)
 
-i18nInit().then(() => {
+const loadMonaco = () =>
+  new Promise<void>((res) => {
+    loader.config({ monaco })
+
+    self.MonacoEnvironment = {
+      createTrustedTypesPolicy() {
+        return undefined
+      },
+      getWorker(_, label) {
+        if (label === 'json') {
+          return new jsonWorker()
+        }
+
+        if (label === 'css' || label === 'scss' || label === 'less') {
+          return new cssWorker()
+        }
+
+        if (label === 'html' || label === 'handlebars' || label === 'razor') {
+          return new htmlWorker()
+        }
+
+        if (label === 'typescript' || label === 'javascript') {
+          return new tsWorker()
+        }
+
+        return new editorWorker()
+      },
+    }
+
+    loader.init().then((monaco) => {
+      import('monaco-themes/themes/GitHub.json').then((data) => {
+        monaco.editor.defineTheme(EDITOR_THEME_LIGHT, data as editor.IStandaloneThemeData)
+
+        res()
+      })
+    })
+  })
+
+Promise.all([i18nInit(), loadMonaco()]).then(() => {
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<App />)
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable import/default */
+
 import '~/index.css'
 
 import { loader } from '@monaco-editor/react'


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="656" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/fc2315d4-b27b-4219-8ee6-515554a55ffe">

This PR adds a new feature, use theme `github` as default monaco editor light theme

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat: use theme `github` as default monaco editor light theme
- feat: add a 4 pixel border radius container to wrap editor

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
