### PR TITLE
ci: introduce generate-changelogs workflow

### DIFF
--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Generate release changelogs
-        uses: daeuniverse/changelogs-generator-action@test
+        uses: daeuniverse/changelogs-generator-action@main
         id: changelog
         with:
           # https://github.com/daeuniverse/changelogs-generator-action
           previousRelease: ${{ inputs.previous_release_tag }}
           futureRelease: ${{ inputs.future_release_tag }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Print outputs
         shell: bash
@@ -37,8 +37,8 @@ jobs:
       - name: Create an issue with proposed changelogs
         uses: dacbd/create-issue-action@main
         with:
-          token: ${{ github.token }}
-          title: '[Release Changelogs] v0.1.0'
+          token: ${{ secrets.GH_TOKEN }}
+          title: '[Release Changelogs] ${{ inputs.future_release_tag }}'
           labels: automated-issue,release
           assignees: daebot
           body: |

--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -33,6 +33,7 @@ jobs:
         shell: bash
         run: |
           echo "${{ steps.changelog.outputs.changelogs }}"
+
       - name: Create an issue with proposed changelogs
         uses: dacbd/create-issue-action@main
         with:

--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -10,9 +10,6 @@ on:
       future_release_tag:
         required: true
         description: future release tag
-  push:
-    branches:
-      - 'changelogs-gen'
 
 jobs:
   build:

--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -1,0 +1,47 @@
+name: Generate Changelogs
+run-name: 'chore(release): generate changelogs for ${{ inputs.previous_release_tag }}..${{ inputs.future_release_tag }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      previous_release_tag:
+        required: true
+        description: previous release tag
+      future_release_tag:
+        required: true
+        description: future release tag
+  push:
+    branches:
+      - 'changelogs-gen'
+
+jobs:
+  build:
+    name: Generate changelogs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Generate release changelogs
+        uses: daeuniverse/changelogs-generator-action@test
+        id: changelog
+        with:
+          # https://github.com/daeuniverse/changelogs-generator-action
+          previousRelease: ${{ inputs.previous_release_tag }}
+          futureRelease: ${{ inputs.future_release_tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print outputs
+        shell: bash
+        run: |
+          echo "${{ steps.changelog.outputs.changelogs }}"
+      - name: Create an issue with proposed changelogs
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: '[Release Changelogs] v0.1.0'
+          labels: automated-issue,release
+          assignees: daebot
+          body: |
+            ${{ steps.changelog.outputs.changelogs }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,10 +3,10 @@ run-name: Publish prerelease ${{ github.ref_name }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*.*.*rc*'
-      - 'v*.*.*p*'
+    inputs:
+      tag:
+        type: string
+        required: true
 
 jobs:
   checkout-full-src:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daed",
   "private": true,
-  "version": "v0.0.1",
+  "version": "v0.1.0",
   "license": "MIT",
   "homepage": "https://daeuniverse.github.io/daed",
   "repository": "https://github.com/daeuniverse/daed",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests, introduce the `generate-changelogs` workflow to make changelogs content management much easier.

Associated project: https://github.com/daeuniverse/changelogs-generator-action

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- chore(package.json): bump up version to v0.1.0
- ci(prerelease): demise tag-based trigger; use distpatch trigger instead
- ci(changelogs): add generate-changelogs workflow

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Test result is avilable in https://github.com/daeuniverse/daed/issues/103

### Workflow run

https://github.com/daeuniverse/daed/actions/runs/5362304326/jobs/9729072058
