### PR TITLE
feat(editor): add routingA code highlight

### DIFF
--- a/src/components/PlainTextFormModal.tsx
+++ b/src/components/PlainTextFormModal.tsx
@@ -86,6 +86,7 @@ export const PlainTextFormModal = forwardRef(
                   height={320}
                   theme={colorScheme === 'dark' ? EDITOR_THEME_DARK : EDITOR_THEME_LIGHT}
                   options={EDITOR_OPTIONS}
+                  language="routingA"
                   value={form.values.text}
                   onChange={(value) => form.setFieldValue('text', value || '')}
                 />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -54,28 +54,30 @@ const loadMonaco = () =>
       monaco.languages.register({ id: 'routingA', extensions: ['dae'] })
 
       monaco.languages.setMonarchTokensProvider('routingA', {
-        defaultToken: 'invalid',
+        // set defaultToken as `invalid` to turn on debug mode
+        // defaultToken: 'invalid',
         ignoreCase: false,
         keywords: [
-          // routing
+          'dip',
+          'direct',
+          'domain',
+          'dport',
+          'fallback',
           'geoip',
           'geosite',
-          'pname',
-          'dip',
-          'sip',
-          'dport',
-          'sport',
-          'l4proto',
           'ipversion',
+          'l4proto',
           'mac',
-          'domain',
-          'fallback',
-          'upstream',
-          // dns
-          'routing',
+          'pname',
           'qname',
           'request',
           'response',
+          'routing',
+          'sip',
+          'sport',
+          'tcp',
+          'udp',
+          'upstream',
         ],
         brackets: [
           {
@@ -90,9 +92,11 @@ const loadMonaco = () =>
           },
         ],
 
+        escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
         operators: ['->', '&&', '!', ':'],
 
-        symbols: /[->&!:,.]+/,
+        symbols: /[->&!:,]+/,
 
         tokenizer: {
           root: [
@@ -104,17 +108,26 @@ const loadMonaco = () =>
 
             [/[,]/, 'delimiter'],
 
-            [/"([^"\\]|\\.)*$/, 'string.invalid'],
-            [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+            [/\d+/, 'number'],
 
-            [/'[^\\']'/, 'string'],
-            [/'/, 'string.invalid'],
+            [/"([^"\\]|\\.)*$/, 'string.invalid'],
+            [/'([^'\\]|\\.)*$/, 'string.invalid'],
+            [/"/, 'string', '@string_double'],
+            [/'/, 'string', '@string_single'],
           ],
 
-          string: [
+          string_double: [
             [/[^\\"]+/, 'string'],
+            [/@escapes/, 'string.escape'],
             [/\\./, 'string.escape.invalid'],
-            [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
+            [/"/, 'string', '@pop'],
+          ],
+
+          string_single: [
+            [/[^\\']+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/'/, 'string', '@pop'],
           ],
 
           whitespace: [

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -51,6 +51,79 @@ const loadMonaco = () =>
     }
 
     loader.init().then((monaco) => {
+      monaco.languages.register({ id: 'routingA', extensions: ['dae'] })
+
+      monaco.languages.setMonarchTokensProvider('routingA', {
+        defaultToken: 'invalid',
+        ignoreCase: false,
+        keywords: [
+          // routing
+          'geoip',
+          'geosite',
+          'pname',
+          'dip',
+          'sip',
+          'dport',
+          'sport',
+          'l4proto',
+          'ipversion',
+          'mac',
+          'domain',
+          'fallback',
+          'upstream',
+          // dns
+          'routing',
+          'qname',
+          'request',
+          'response',
+        ],
+        brackets: [
+          {
+            open: '{',
+            close: '}',
+            token: 'delimiter.brackets',
+          },
+          {
+            open: '(',
+            close: ')',
+            token: 'delimiter.parenthesis',
+          },
+        ],
+
+        operators: ['->', '&&', '!', ':'],
+
+        symbols: /[->&!:,.]+/,
+
+        tokenizer: {
+          root: [
+            [/[a-z_$][\w$]*/, { cases: { '@keywords': 'keyword', '@default': 'identifier' } }],
+            { include: '@whitespace' },
+
+            [/[{}()]/, '@brackets'],
+            [/@symbols/, { cases: { '@operators': 'operator', '@default': '' } }],
+
+            [/[,]/, 'delimiter'],
+
+            [/"([^"\\]|\\.)*$/, 'string.invalid'],
+            [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+
+            [/'[^\\']'/, 'string'],
+            [/'/, 'string.invalid'],
+          ],
+
+          string: [
+            [/[^\\"]+/, 'string'],
+            [/\\./, 'string.escape.invalid'],
+            [/"/, { token: 'string.quote', bracket: '@close', next: '@pop' }],
+          ],
+
+          whitespace: [
+            [/[ \t\r\n]+/, 'white'],
+            [/#.*$/, 'comment'],
+          ],
+        },
+      })
+
       import('monaco-themes/themes/GitHub.json').then((data) => {
         monaco.editor.defineTheme(EDITOR_THEME_LIGHT, data as editor.IStandaloneThemeData)
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="634" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/fa96b4a4-213e-4f01-9aa5-d88b25d44b9e">

<img width="645" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/6bd74380-420c-4b6f-bcbd-be8d117f6a72">

This PR adds code highlight support for routingA files, including dns and routing.

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat(editor): add routingA code highlight

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
