### PR TITLE
feat(editor): render tags

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 import { EditorProps } from '@monaco-editor/react'
 import { TFunction } from 'i18next'
+import { languages } from 'monaco-editor'
 import { z } from 'zod'
 
 import { GlobalInput, Policy } from '~/schemas/gql/graphql'
@@ -199,7 +200,7 @@ export const EDITOR_OPTIONS: EditorProps['options'] = {
   minimap: {
     enabled: false,
   },
-  renderWhitespace: 'all',
+  renderWhitespace: 'selection',
   cursorBlinking: 'solid',
   formatOnPaste: true,
   insertSpaces: true,
@@ -208,6 +209,81 @@ export const EDITOR_OPTIONS: EditorProps['options'] = {
   padding: {
     top: 8,
     bottom: 8,
+  },
+}
+
+export const EDITOR_LANGUAGE_ROUTINGA: languages.IMonarchLanguage = {
+  // set defaultToken as `invalid` to turn on debug mode
+  // defaultToken: 'invalid',
+  ignoreCase: false,
+  keywords: [
+    'dip',
+    'direct',
+    'domain',
+    'dport',
+    'fallback',
+    'geoip',
+    'geosite',
+    'ipversion',
+    'l4proto',
+    'mac',
+    'pname',
+    'qname',
+    'request',
+    'response',
+    'routing',
+    'sip',
+    'sport',
+    'tcp',
+    'udp',
+    'upstream',
+  ],
+
+  escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+  symbols: /[->&!:,]+/,
+
+  operators: ['&&', '!'],
+
+  tokenizer: {
+    root: [
+      [/@[a-zA-Z]\w*/, 'tag'],
+      [/[a-zA-Z]\w*/, { cases: { '@keywords': 'keyword', '@default': 'identifier' } }],
+
+      { include: '@whitespace' },
+
+      [/[{}()]/, '@brackets'],
+
+      [/@symbols/, { cases: { '@operators': 'operator', '@default': '' } }],
+
+      [/\d+/, 'number'],
+
+      [/[,:]/, 'delimiter'],
+
+      [/"([^"\\]|\\.)*$/, 'string.invalid'],
+      [/'([^'\\]|\\.)*$/, 'string.invalid'],
+      [/"/, 'string', '@string_double'],
+      [/'/, 'string', '@string_single'],
+    ],
+
+    string_double: [
+      [/[^\\"]+/, 'string'],
+      [/@escapes/, 'string.escape'],
+      [/\\./, 'string.escape.invalid'],
+      [/"/, 'string', '@pop'],
+    ],
+
+    string_single: [
+      [/[^\\']+/, 'string'],
+      [/@escapes/, 'string.escape'],
+      [/\\./, 'string.escape.invalid'],
+      [/'/, 'string', '@pop'],
+    ],
+
+    whitespace: [
+      [/[ \t\r\n]+/, 'white'],
+      [/#.*$/, 'comment'],
+    ],
   },
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,7 @@ import ReactDOM from 'react-dom/client'
 import { App } from '~/App'
 import { i18nInit } from '~/i18n'
 
-import { EDITOR_THEME_LIGHT } from './constants'
+import { EDITOR_LANGUAGE_ROUTINGA, EDITOR_THEME_LIGHT } from './constants'
 
 dayjs.extend(duration)
 
@@ -52,90 +52,7 @@ const loadMonaco = () =>
 
     loader.init().then((monaco) => {
       monaco.languages.register({ id: 'routingA', extensions: ['dae'] })
-
-      monaco.languages.setMonarchTokensProvider('routingA', {
-        // set defaultToken as `invalid` to turn on debug mode
-        // defaultToken: 'invalid',
-        ignoreCase: false,
-        keywords: [
-          'dip',
-          'direct',
-          'domain',
-          'dport',
-          'fallback',
-          'geoip',
-          'geosite',
-          'ipversion',
-          'l4proto',
-          'mac',
-          'pname',
-          'qname',
-          'request',
-          'response',
-          'routing',
-          'sip',
-          'sport',
-          'tcp',
-          'udp',
-          'upstream',
-        ],
-        brackets: [
-          {
-            open: '{',
-            close: '}',
-            token: 'delimiter.brackets',
-          },
-          {
-            open: '(',
-            close: ')',
-            token: 'delimiter.parenthesis',
-          },
-        ],
-
-        escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
-
-        operators: ['->', '&&', '!', ':'],
-
-        symbols: /[->&!:,]+/,
-
-        tokenizer: {
-          root: [
-            [/[a-z_$][\w$]*/, { cases: { '@keywords': 'keyword', '@default': 'identifier' } }],
-            { include: '@whitespace' },
-
-            [/[{}()]/, '@brackets'],
-            [/@symbols/, { cases: { '@operators': 'operator', '@default': '' } }],
-
-            [/[,]/, 'delimiter'],
-
-            [/\d+/, 'number'],
-
-            [/"([^"\\]|\\.)*$/, 'string.invalid'],
-            [/'([^'\\]|\\.)*$/, 'string.invalid'],
-            [/"/, 'string', '@string_double'],
-            [/'/, 'string', '@string_single'],
-          ],
-
-          string_double: [
-            [/[^\\"]+/, 'string'],
-            [/@escapes/, 'string.escape'],
-            [/\\./, 'string.escape.invalid'],
-            [/"/, 'string', '@pop'],
-          ],
-
-          string_single: [
-            [/[^\\']+/, 'string'],
-            [/@escapes/, 'string.escape'],
-            [/\\./, 'string.escape.invalid'],
-            [/'/, 'string', '@pop'],
-          ],
-
-          whitespace: [
-            [/[ \t\r\n]+/, 'white'],
-            [/#.*$/, 'comment'],
-          ],
-        },
-      })
+      monaco.languages.setMonarchTokensProvider('routingA', EDITOR_LANGUAGE_ROUTINGA)
 
       import('monaco-themes/themes/GitHub.json').then((data) => {
         monaco.editor.defineTheme(EDITOR_THEME_LIGHT, data as editor.IStandaloneThemeData)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="528" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/36ca8f27-0b5f-473b-ab50-2b98b548cdac">

<img width="438" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/0d3cb258-d94f-43c0-937d-8ced578d1f04">

This PR adds a new feature, allow editor to render a rule without quotes as tag.

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat(editor): render tags

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
