### PR TITLE
feat: add header icon link to github project, and a footer

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import {
   ActionIcon,
+  Anchor,
   Avatar,
   Box,
   Center,
@@ -23,6 +24,7 @@ import {
 import { useForm, zodResolver } from '@mantine/form'
 import { useDisclosure } from '@mantine/hooks'
 import {
+  IconBrandGithub,
   IconChevronDown,
   IconCloudCheck,
   IconCloudComputing,
@@ -203,6 +205,12 @@ export const Header = () => {
                 </Menu.Item>
               </Menu.Dropdown>
             </Menu>
+
+            <Anchor href="https://github.com/daeuniverse/daed" target="_blank">
+              <ActionIcon>
+                <IconBrandGithub />
+              </ActionIcon>
+            </Anchor>
 
             <ActionIcon
               onClick={() => {

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Container, ScrollArea, Stack } from '@mantine/core'
+import { Anchor, Center, Container, Footer, ScrollArea, Stack, Text } from '@mantine/core'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
@@ -180,6 +180,17 @@ export const MainLayout = () => {
           </Container>
         </ScrollArea>
       </main>
+
+      <Footer height={50}>
+        <Center h="100%">
+          <Text fw="lighter" fz="xs" color="dimmed">
+            Made with passion 🔥 by{' '}
+            <Anchor href="https://github.com/daeuniverse" target="_blank">
+              @daeuniverse
+            </Anchor>
+          </Text>
+        </Center>
+      </Footer>
     </Stack>
   )
 }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="414" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/7e2a365b-c049-44ac-ab84-e2803a69b089">

<img width="1512" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/279be541-757a-48b6-86d2-d3cd96434316">

This PR adds a header icon link to github project, also adds a new footer section

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- feat: add header icon link to github project, and a footer

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None
