### PR TITLE
chore: refine makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ clean:
 ## Begin Git Submodules
 .gitmodules.d.mk: .gitmodules Makefile
 	@set -e && \
-	submodules=$$(grep '\[submodule "' .gitmodules | cut -d'"' -f2 | tr '\n' ' ' | tr ' \n' '\n') && \
-	echo "submodule_ready=$${submodules}/.git" > $@
+	submodules=$$(grep '\[submodule "' .gitmodules | cut -d'"' -f2 | tr '\n' ' ' | tr ' \n' '\n' | sed 's/$$/\/.git/g') && \
+	echo "submodule_ready=$${submodules}" > $@
 
 -include .gitmodules.d.mk
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

If there are multiple submodules, the previous wording only concatenates `/.git` to the last element of the `submodule_ready` array.

This PR is to fix it.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- Use `sed` to concatenate `/.git` to every element of the `submodule_ready` array.


