### PR TITLE
ci: refine pr-build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
-name: Build
+name: Build (Stable)
 
 on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - README.md
 
 jobs:
   checkout-full-src:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   context:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,19 +1,26 @@
-name: Build (Nightly)
+name: PR Build (Preview)
+run-name: '#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.sha }}'
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - hotfix-*
-      - test-pr-*
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**/*.md'
       - README.md
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
+  context:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
   checkout-full-src:
+    needs: context
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,6 @@ jobs:
           echo "$GITHUB_CONTEXT"
 
   checkout-full-src:
-    needs: context
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,9 +8,9 @@
 
 Releases are available in <https://github.com/daeuniverse/daed/releases>
 
-> **Note**: If you would like to get a taste of new features, there are nightly (latest) builds available. Most of the time, newly proposed changes will be included in `PRs` and will be exported as cross-platform executable binaries in builds (GitHub Action Workflow Build). Noted that newly introduced features are sometimes buggy, do it at your own risk. However, we still highly encourage you to check out our latest builds as it may help us further analyze features stability and resolve potential bugs accordingly.
+> **Note**: If you would like to get a taste of new features, there are `PR Builds` available. Most of the time, newly proposed changes will be included in `PRs` and will be exported as cross-platform executable binaries in builds (GitHub Action Workflow Build). Noted that newly introduced features are sometimes buggy, do it at your own risk. However, we still highly encourage you to check out our latest builds as it may help us further analyze features stability and resolve potential bugs accordingly.
 
-Nightly builds are available in <https://github.com/daeuniverse/daed/actions/workflows/build-nightly.yml>
+PR-builds are available in <https://github.com/daeuniverse/daed/actions/workflows/pr-build.yml>
 
 ### Spin up server locally
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Mimic proposed changes in https://github.com/daeuniverse/dae/pull/183

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- docs(getting-started): rename nightly build to pr-build
- refactor(workflow): rename build-nightly -> pr-build
- ci: add run_name followed by `#pr_number - pr_title @pr_ref:pr_sha`
- ci: add initial job to show pr context
- refactor(build): update workflow title from Build to Build (Stable)
- ci: make context an independent job

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

https://github.com/daeuniverse/daed/actions/runs/5497492906

<img width="910" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/f23e2965-91d9-4027-b6e0-8b215fcfa900">
