### PR TITLE
ci(generate-changelogs): set dry_run to true by default

### DIFF
--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -10,6 +10,10 @@ on:
       future_release_tag:
         required: true
         description: future release tag
+      dry_run:
+        required: true
+        description: export changelogs to an issue page
+        default: true
 
 jobs:
   build:
@@ -35,6 +39,7 @@ jobs:
           echo "${{ steps.changelog.outputs.changelogs }}"
 
       - name: Create an issue with proposed changelogs
+        if: ${{ inputs.dry_run == 'false' }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/daed/blob/main/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Replicate PR - https://github.com/daeuniverse/dae/pull/201

Prevent writing changelogs to GitHub issues by default.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full changelog

- ci(generate-changelogs): set dry_run to true by default

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

https://github.com/daeuniverse/dae-1/actions/runs/5508370825
