### PR TITLE
fix: wan interface should be optional

### DIFF
--- a/src/components/ConfigFormModal.tsx
+++ b/src/components/ConfigFormModal.tsx
@@ -59,7 +59,7 @@ const schema = z.object({
   checkToleranceMS: z.number(),
   sniffingTimeoutMS: z.number(),
   lanInterface: z.array(z.string().nonempty()),
-  wanInterface: z.array(z.string().nonempty()).min(1),
+  wanInterface: z.array(z.string()),
   udpCheckDns: z.array(z.string()).min(1),
   tcpCheckUrl: z.array(z.string()).min(1),
   dialMode: z.string(),
@@ -338,7 +338,6 @@ export const ConfigFormDrawer = forwardRef(({ opened, onClose }: { opened: boole
                     label={t('wanInterface')}
                     description={t('descriptions.config.wanInterface')}
                     itemComponent={SelectItemWithDescription}
-                    withAsterisk
                     data={wanInterfacesData}
                     {...form.getInputProps('wanInterface')}
                   />


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="383" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/2528c8e8-de20-4dbc-9644-e08482bb9ec5">

This PR fixes a issue, instead of required, wan interface field should be optional

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- fix: wan interface should be optional

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None

### Test Result

<!--- Attach test result here. -->
