### PR TITLE
fix(v2ray): add missing websocket path field

### DIFF
--- a/src/components/ConfigureNodeFormModal/TuicForm.tsx
+++ b/src/components/ConfigureNodeFormModal/TuicForm.tsx
@@ -62,10 +62,10 @@ export const TuicForm = ({ onLinkGeneration }: { onLinkGeneration: (link: string
 
       <TextInput label="SNI" {...getInputProps('sni')} />
 
-      <Checkbox label="Disable SNI" {...getInputProps('disable_sni', { type: 'checkbox' })} />
+      <Checkbox label={t('configureNode.disableSNI')} {...getInputProps('disable_sni', { type: 'checkbox' })} />
 
       <Select
-        label="UDP Relay Mode"
+        label={t('configureNode.udpRelayMode')}
         data={[
           { label: 'native', value: 'native' },
           { label: 'quic', value: 'quic' },

--- a/src/components/ConfigureNodeFormModal/V2rayForm.tsx
+++ b/src/components/ConfigureNodeFormModal/V2rayForm.tsx
@@ -192,11 +192,9 @@ export const V2rayForm = ({ onLinkGeneration }: { onLinkGeneration: (link: strin
 
       {values.tls === 'tls' && <TextInput label="Alpn" {...getInputProps('alpn')} />}
 
-      {values.net === 'ws' ||
-        values.net === 'h2' ||
-        (values.net === 'tcp' && values.type === 'http' && (
-          <TextInput label={t('configureNode.path')} {...getInputProps('path')} />
-        ))}
+      {(values.net === 'ws' || values.net === 'h2' || (values.net === 'tcp' && values.type === 'http')) && (
+        <TextInput label={t('configureNode.path')} {...getInputProps('path')} />
+      )}
 
       {values.net === 'kcp' && <TextInput label="Seed" {...getInputProps('path')} />}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,6 +42,7 @@
   "config": "Config",
   "configureNode": {
     "congestionControl": "Congestion Control",
+    "disableSNI": "Disable SNI",
     "dtlsObfuscation": "Obfuscated as DTLS1.2 Packets",
     "forceTLS": "forcibly TLS on",
     "host": "Host",
@@ -65,6 +66,7 @@
     "srtpObfuscation": "Obfuscated as Video Calls (SRTP)",
     "title": "Configure Node",
     "type": "Type",
+    "udpRelayMode": "UDP Relay Mode",
     "username": "Username",
     "utpObfuscation": "Obfuscated as Bittorrent (uTP)",
     "websocketHost": "WebSocket Host",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -42,6 +42,7 @@
   "config": "配置",
   "configureNode": {
     "congestionControl": "拥堵控制算法",
+    "disableSNI": "关闭 SNI",
     "dtlsObfuscation": "伪装为 DTLS1.2 数据包",
     "forceTLS": "强制开启 TLS",
     "host": "主机地址",
@@ -65,6 +66,7 @@
     "srtpObfuscation": "伪装视频通话 (SRTP)",
     "title": "配置节点",
     "type": "类型",
+    "udpRelayMode": "UDP 中继模式",
     "username": "用户名",
     "utpObfuscation": "伪装为 BT 下载 (uTP)",
     "websocketHost": "WebSocket 地址",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="525" alt="image" src="https://github.com/daeuniverse/daed/assets/17328586/14e1723a-582b-42cd-aea8-ff1bf94350bc">

This PR fixes a issue, add missing websocket path field input in configure node form modal

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- fix(v2ray): add missing websocket path field

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

None

### Test Result

<!--- Attach test result here. -->
