### PR TITLE
ci/fix(pr-build): skip check-run related actions based on condition

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-#     if: "${{ startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner) }}"
+#     if: startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,7 +29,7 @@ jobs:
       - run: |
           echo "${{ github.repository_owner }}"
           echo "${{ github.event.pull_request.head.repo.full_name }}"
-          echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+          echo "${{ startsWith(github.repository_owner, github.event.pull_request.head.full_name) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,18 +20,15 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-#     if: "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+#     if: "${{ startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner) }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         id: ["checkout-full-src", "build-web", "build-bundle", "build-passed"]
-    env:
-        EVENT_CONTEXT: ${{ toJson(github.event.pull_request) }}
     steps:
       - run: |
-          echo "$EVENT_CONTEXT"
           echo "${{ github.repository_owner }}"
-          echo "${{ github.event.pull_request.head.full_name }}"
+          echo "${{ github.event.pull_request.head.repo.full_name }}"
           echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-    if: ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
+    if: "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -248,7 +248,7 @@ jobs:
           path: bundled/*
           
       - name: Report result
-        if: always() && ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
+        if: always() && "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -256,7 +256,7 @@ jobs:
           id: "dae-bot[bot]/build-bundle"
 
   conclusion:
-    if: always() && ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
+    if: always() && "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
     needs: [build-bundle]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,6 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
+    if: ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -247,15 +248,15 @@ jobs:
           path: bundled/*
           
       - name: Report result
+        if: always() && ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
-        if: always()
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           id: "dae-bot[bot]/build-bundle"
 
   conclusion:
-    if: always()
+    if: always() && ${{ github.event.pull_request.repo.full_name == "daeuniverse/daed" }}
     needs: [build-bundle]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -31,6 +31,7 @@ jobs:
       - run: |
           echo "$EVENT_CONTEXT"
           echo "${{ github.repository_owner }}"
+          echo "${{ github.event.pull_request.head.full_name }}"
           echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,8 +27,8 @@ jobs:
         id: ["checkout-full-src", "build-web", "build-bundle", "build-passed"]
     steps:
       - run: |
-          echo "{{ github.event.pull_request.head.full_name }}"
-          echo "{{ github.repository_owner }}"
+          echo "${{ github.event.pull_request.head.full_name }}"
+          echo "${{ github.repository_owner }}"
           echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,9 +25,11 @@ jobs:
     strategy:
       matrix:
         id: ["checkout-full-src", "build-web", "build-bundle", "build-passed"]
+    env:
+        EVENT_CONTEXT: ${{ toJson(github.event.pull_request) }}
     steps:
       - run: |
-          echo "${{ github.event.pull_request.head.full_name }}"
+          echo "$EVENT_CONTEXT"
           echo "${{ github.repository_owner }}"
           echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
       - name: Instantiate required check runs

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-    if: "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+#     if: "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,16 +20,12 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-#     if: startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
+    if: startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
     runs-on: ubuntu-latest
     strategy:
       matrix:
         id: ["checkout-full-src", "build-web", "build-bundle", "build-passed"]
     steps:
-      - run: |
-          echo "${{ github.repository_owner }}"
-          echo "${{ github.event.pull_request.head.repo.full_name }}"
-          echo "${{ startsWith(github.repository_owner, github.event.pull_request.head.full_name) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master
         with:
@@ -71,7 +67,7 @@ jobs:
           path: daed-full-src.zip
           
       - name: Report result
-        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+        if: always() && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -104,7 +100,7 @@ jobs:
           path: dist
           
       - name: Report result
-        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+        if: always() && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -252,7 +248,7 @@ jobs:
           path: bundled/*
           
       - name: Report result
-        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+        if: always() && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -260,7 +256,7 @@ jobs:
           id: "dae-bot[bot]/build-bundle"
 
   conclusion:
-    if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
+    if: always() && startsWith(github.event.pull_request.head.repo.full_name, github.repository_owner)
     needs: [build-bundle]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-    if: "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
+    if: "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -67,8 +67,8 @@ jobs:
           path: daed-full-src.zip
           
       - name: Report result
+        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
-        if: always()
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -100,8 +100,8 @@ jobs:
           path: dist
           
       - name: Report result
+        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
-        if: always()
         with:
           app_id: ${{ secrets.GH_APP_ID }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -248,7 +248,7 @@ jobs:
           path: bundled/*
           
       - name: Report result
-        if: always() && "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
+        if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -256,7 +256,7 @@ jobs:
           id: "dae-bot[bot]/build-bundle"
 
   conclusion:
-    if: always() && "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
+    if: always() && "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
     needs: [build-bundle]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,6 +26,10 @@ jobs:
       matrix:
         id: ["checkout-full-src", "build-web", "build-bundle", "build-passed"]
     steps:
+      - run: |
+          echo "{{ github.event.pull_request.head.full_name }}"
+          echo "{{ github.repository_owner }}"
+          echo "${{ startsWith(github.event.pull_request.head.full_name, github.repository_owner) }}"
       - name: Instantiate required check runs
         uses: daeuniverse/ci-seed-jobs/core/daed/instantiate-check-runs@master
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -20,7 +20,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
           
   instantiate-check-runs:
-    if: "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
+    if: "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -248,7 +248,7 @@ jobs:
           path: bundled/*
           
       - name: Report result
-        if: always() && "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
+        if: always() && "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
         uses: daeuniverse/ci-seed-jobs/core/daed/report-check-run@master
         with:
           app_id: ${{ secrets.GH_APP_ID }}
@@ -256,7 +256,7 @@ jobs:
           id: "dae-bot[bot]/build-bundle"
 
   conclusion:
-    if: always() && "${{ github.event.pull_request.repo.full_name == 'daeuniverse/daed' }}"
+    if: always() && "${{ github.event.pull_request.repo.full_name == daeuniverse/daed }}"
     needs: [build-bundle]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Contributors outside of `daeuniverse` is NOT able to kick of the pr-build because insufficient permission to instantiate check-runs. This PR proposes changes to resolve it by skipping those `check-runs` related actions.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci/fix(pr-build): skip check-run related actions based on condition

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

Scenario 1: contributor is a member of daeuniverse org

https://github.com/daeuniverse/daed/actions/runs/5561342029/jobs/10158963914

Scenario 2: contributor is outside of daeuniverse org

TBD.