### PR TITLE
ci(pr-build): add ready_for_review trigger

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,7 +4,7 @@ run-name: '#${{ github.event.pull_request.number }} - ${{ github.event.pull_requ
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**/*.md'
       - README.md


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add `pr.ready_for_review` trigger in `PR Build (Preview)`. It should trigger PR build when a drafted PR converts to `ready for review` state.

Ref: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=ready_for_review#pull_request

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): add pr.ready_for_review trigger

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA