### PR TITLE
ci(release,pr-build,build): checkout codebase based on ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          ref: ${{ inputs.tag }}
 
       - name: Download wing vendor
         run: |
@@ -40,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v2
         with:
@@ -126,6 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.tag }}
           fetch-depth: 0
 
       - name: Get the version


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Check out to codebase based on a given `github.sha`. This is necessary when we do future releases.

Quoted from <https://github.com/actions/checkout>

```yml
   # The branch, tag or SHA to checkout. When checking out the repository that
   # triggered a workflow, this defaults to the reference or SHA for that event.
   # Otherwise, uses the default branch.
   ref: ''
```

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(seed-build): checkout codebase based on ref

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA
