### PR TITLE
ci(pr-build): ONLY keep arm64, amd64 as build targets

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -114,32 +114,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [arm64]
-
-        include:
-          # BEGIN Linux ARM 5 6 7
-          - goos: linux
-            goarch: arm
-            goarm: 7
-          - goos: linux
-            goarch: arm
-            goarm: 6
-          - goos: linux
-            goarch: arm
-            goarm: 5
-          # END Linux ARM 5 6 7
-
-          # BEGIN Linux AMD64 v1 v2 v3
-          - goos: linux
-            goarch: amd64
-            goamd64: v1
-          - goos: linux
-            goarch: amd64
-            goamd64: v2
-          - goos: linux
-            goarch: amd64
-            goamd64: v3
-          # END Linux AMD64 v1 v2 v3
+        goarch: [arm64, amd64]
       fail-fast: false
 
     env:
@@ -207,7 +182,7 @@ jobs:
           curl -L -o ./bundled/geosite.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geosite.dat
 
       - name: Smoking test
-        if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
+        if: matrix.goarch == 'amd64'
         run: ./bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }} --version
 
       - name: Create binary ZIP archive and Signature

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -113,8 +113,11 @@ jobs:
 
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [arm64, amd64]
+        include:
+          - goos: linux
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
       fail-fast: false
 
     env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -115,6 +115,18 @@ jobs:
       matrix:
         goos: [linux]
         goarch: [arm64,amd64]
+        include:
+          # BEGIN Linux ARM 5 6 7
+          - goos: linux
+            goarch: arm
+            goarm: 7
+          - goos: linux
+            goarch: arm
+            goarm: 6
+          - goos: linux
+            goarch: arm
+            goarm: 5
+          # END Linux ARM 5 6 7
       fail-fast: false
 
     env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [arm64, 386, riscv64, mips64, mips64le, mipsle, mips]
+        goarch: [arm64]
 
         include:
           # BEGIN Linux ARM 5 6 7
@@ -140,25 +140,6 @@ jobs:
             goarch: amd64
             goamd64: v3
           # END Linux AMD64 v1 v2 v3
-
-          # BEGIN Linux mips
-          - goos: linux
-            goarch: mips64
-            cgo_enabled: 1
-            cc: mips64-linux-gnuabi64-gcc
-          - goos: linux
-            goarch: mips64le
-            cgo_enabled: 1
-            cc: mips64el-linux-gnuabi64-gcc
-          - goos: linux
-            goarch: mipsle
-            cgo_enabled: 1
-            cc: mipsel-linux-gnu-gcc
-          - goos: linux
-            goarch: mips
-            cgo_enabled: 1
-            cc: mips-linux-gnu-gcc
-          # END Linux mips
       fail-fast: false
 
     env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -113,11 +113,8 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - goos: linux
-            goarch: arm64
-          - goos: linux
-            goarch: amd64
+        goos: [linux]
+        goarch: [arm64,amd64]
       fail-fast: false
 
     env:

--- a/install/friendly-filenames.json
+++ b/install/friendly-filenames.json
@@ -3,6 +3,7 @@
   "linux-amd64v1": { "friendlyName": "linux-x86_64" },
   "linux-amd64v2": { "friendlyName": "linux-x86_64_v2_sse" },
   "linux-amd64v3": { "friendlyName": "linux-x86_64_v3_avx2" },
+  "linux-amd64": { "friendlyName": "linux-x86_64" },
   "linux-arm5": { "friendlyName": "linux-armv5" },
   "linux-arm6": { "friendlyName": "linux-armv6" },
   "linux-arm7": { "friendlyName": "linux-armv7" },


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests. The idea is to drastically reduce build time.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): ONLY keep arm64, amd64 as build targets
- patch(friendly-filenames.json): add entry for amd64 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

<img width="1028" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/5ee3702f-f725-4666-8d9b-a220eedbafb1">

<img width="640" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/bb255568-df0f-432c-ad23-48bd2a803b4a">
