### PR TITLE
fix: avoid to install husky when not in a git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,12 @@ submodule submodules: $(submodule_ready)
 ## End Git Submodules
 
 ## Begin Web
+PFLAGS ?=
+ifeq (,$(wildcard ./.git))
+	PFLAGS += HUSKY=0
+endif
 dist: package.json pnpm-lock.yaml
-	pnpm i
+	$(PFLAGS) pnpm i
 	pnpm build
 ## End Web
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

https://paste.opensuse.org/pastes/48a22a1d153b

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- [Implement ...]

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
