### PR TITLE
ci/fix(pr-build,build): fix submodule path trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [main]
     paths:
+      - 'src/**'
+      - 'public/**'
       - .github/workflows/pr-build.yml
       - install/friendly-filenames.json
       - Makefile
-      - 'wing/**'
-      - 'src/**'
-      - 'public/**'
+      - wing
       - index.html
       - vite.config.ts
       - .npmrc

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - 'src/**'
+      - 'public/**'
       - .github/workflows/pr-build.yml
       - install/friendly-filenames.json
       - Makefile
-      - 'wing/**'
-      - 'src/**'
-      - 'public/**'
+      - wing
       - index.html
       - vite.config.ts
       - .npmrc


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Fix the issue where changes made to `wing (submodule)` do NOT trigger the build, pr-build workflow. 

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci/fix(pr-build): fix submodule path trigger 
- ci/fix(build): fix submodule path trigger 

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

https://github.com/daeuniverse/daed/actions/runs/5692285650

<img width="704" alt="image" src="https://github.com/daeuniverse/daed/assets/31861128/24500d08-d30c-4f29-9fbe-ba81346a1b1c">
