### PR TITLE
ci: add pick-build workflow

### DIFF
--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -32,7 +32,7 @@ jobs:
           git checkout ${{ github.event.inputs.wing }}
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
-          cd dae-core && git merge origin/${{ github.event.inputs.dae-core }} && go mod download -modcacherw && cd ..
+          cd dae-core && git checkout ${{ github.event.inputs.dae-core }} && go mod download -modcacherw && cd ..
           find "$GOMODCACHE" -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
           sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
         working-directory: wing
@@ -154,8 +154,8 @@ jobs:
       - name: Pick wing and dae-core
         run: |
           git submodule update --init --recursive
-          cd wing && git reset --hard remotes/origin/${{ github.event.inputs.wing }}
-          cd dae-core && git reset --hard remotes/origin/${{ github.event.inputs.dae-core }} && cd ../..
+          cd wing && git reset --hard ${{ github.event.inputs.wing }} && go mod download -modcacherw
+          cd dae-core && git reset --hard ${{ github.event.inputs.dae-core }} && cd ../..
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -1,15 +1,15 @@
-name: Custom Build (Preview)
-run-name: Deploy to '#${{ input.deploy_target }} by @${{ github.actor }}'
+name: Pick Build (Preview)
+run-name: Build to '#${{ github.event.inputs.dae-core }} by @${{ github.actor }}'
 
 on:
   workflow_dispatch:
     inputs:
-      wing-commit-hash:
-        description: 'Commit hash for wing'
+      wing:
+        description: 'Commit hash or branch for wing'
         required: false
         default: 'main' # Default to latest commit on main branch
-      dae-core-hash:
-        description: 'Commit hash for dae-core'
+      dae-core:
+        description: 'Commit hash or branch for dae-core'
         required: true
 
 jobs:
@@ -32,10 +32,10 @@ jobs:
       - name: Download wing vendor
         run: |
           git submodule update --init --recursive
-          git checkout ${{ github.event.inputs.wing-commit-hash }}
+          git checkout ${{ github.event.inputs.wing }}
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
-          cd dae-core && git checkout ${{ github.event.inputs.dae-core-hash }} && go mod download -modcacherw && cd ..
+          cd dae-core && git checkout ${{ github.event.inputs.dae-core }} && go mod download -modcacherw && cd ..
           find "$GOMODCACHE" -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
           sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
         working-directory: wing

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -5,15 +5,15 @@ on:
   workflow_dispatch:
     inputs:
       daed:
-        description: 'Commit ID or branch for daed'
+        description: 'Commit ID or branch name for daed'
         required: false
         default: 'main'
       wing:
-        description: 'Commit ID or branch for wing'
+        description: 'Commit ID or branch name for wing'
         required: false
         default: 'main'
       dae-core:
-        description: 'Commit ID or branch for dae-core'
+        description: 'Commit ID or branch name for dae-core'
         required: false
         default: 'main'
 

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -23,17 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.inputs.daed }}
           submodules: 'recursive'
-
-      - name: Pick daed
-        run: |
-          git remote update
-          git checkout ${{ github.event.inputs.daed }}
+          fetch-depth: 0
 
       - name: Download wing vendor
         run: |
-          git remote update
-          git submodule update --init --recursive
           git checkout ${{ github.event.inputs.wing }}
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
@@ -64,7 +59,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.daed }}
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
         with:
@@ -153,22 +147,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.daed }}
+          fetch-depth: 0
+
+      - name: Pick wing and dae-core
+        run: |
+          git submodule update --init --recursive
+          cd wing && git reset --hard remotes/origin/${{ github.event.inputs.wing }}
+          cd dae-core && git reset --hard remotes/origin/${{ github.event.inputs.dae-core }} && cd ../..
 
       - name: Get the version
         id: get_version
         env:
-          REF: ${{ github.ref }}
+          DAED_REF: ${{ github.event.inputs.daed }}
+          WING_REF: ${{ github.event.inputs.wing }}
+          DAE_CORE_REF: ${{ github.event.inputs.dae-core }}
         run: |
-          if [[ "$REF" == "refs/tags/v"* ]]; then
-            tag=${REF##*/}
-            version=${tag}
-            package_version="${tag:1}"
+          date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+          if [[ "$DAED_REF" == "main" && "$WING_REF" == "main" && "$DAE_CORE_REF" == "main" ]]; then
+            version="Ultimate-${date}"
+            package_version="Ultimate"
           else
-            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
-            count=$(git rev-list --count HEAD)
-            commit=$(git rev-parse --short HEAD)
-            version="unstable-$date.r${count}.$commit"
-            package_version="$date.r${count}.$commit"
+            daed_commit=$(git rev-parse --short HEAD) && cd wing
+            wing_commit=$(git rev-parse --short HEAD) && cd dae-core
+            dae_core_commit=$(git rev-parse --short HEAD)
+            version="$frontier-$daed_commit.$wing_commit.$dae_core_commit"
+            package_version="$frontier-$daed_commit.$wing_commit.$dae_core_commit"
           fi
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
@@ -193,12 +198,6 @@ jobs:
         with:
           name: web
           path: dist/
-
-      - name: Pick wing and dae-core
-        run: |
-          git submodule update --init --recursive
-          cd wing && git reset --hard remotes/origin/${{ github.event.inputs.wing }}
-          cd dae-core && git reset --hard remotes/origin/${{ github.event.inputs.dae-core }} && cd ../..
 
       - name: Change Makefile
         if: ${{ !endsWith(matrix.goarch, '64') || startsWith(matrix.goarch, 'mips') }}

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -1,0 +1,181 @@
+name: Custom Build (Preview)
+run-name: Deploy to '#${{ input.deploy_target }} by @${{ github.actor }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      wing-commit-hash:
+        description: 'Commit hash for wing'
+        required: false
+        default: 'main' # Default to latest commit on main branch
+      dae-core-hash:
+        description: 'Commit hash for dae-core'
+        required: true
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
+  checkout-full-src:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Download wing vendor
+        run: |
+          git submodule update --init --recursive
+          git checkout ${{ github.event.inputs.wing-commit-hash }}
+          export GOMODCACHE="${PWD}"/go-mod
+          go mod download -modcacherw
+          cd dae-core && git checkout ${{ github.event.inputs.dae-core-hash }} && go mod download -modcacherw && cd ..
+          find "$GOMODCACHE" -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
+          sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
+        working-directory: wing
+
+      - name: Create full source ZIP archive and Signature
+        run: |
+          zip -9vr daed-full-src.zip . -x .git/\*
+
+      - name: Upload artifact - full source
+        uses: actions/upload-artifact@v3
+        with:
+          name: daed-full-src.zip
+          path: daed-full-src.zip
+
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: pnpm
+          node-version: latest
+
+      - name: Build
+        run: |
+          pnpm install
+          pnpm build
+
+      - name: Upload artifact - web
+        uses: actions/upload-artifact@v3
+        with:
+          name: web
+          path: dist
+
+  build-bundle:
+    needs: build-web
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [arm64, amd64]
+        include:
+          # BEGIN Linux ARM 5 6 7
+          - goos: linux
+            goarch: arm
+            goarm: 7
+          - goos: linux
+            goarch: arm
+            goarm: 6
+          - goos: linux
+            goarch: arm
+            goarm: 5
+          # END Linux ARM 5 6 7
+      fail-fast: false
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      GOARM: ${{ matrix.goarm }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get the version
+        id: get_version
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "$REF" == "refs/tags/v"* ]]; then
+            tag=${REF##*/}
+            version=${tag}
+            package_version="${tag:1}"
+          else
+            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+            count=$(git rev-list --count HEAD)
+            commit=$(git rev-parse --short HEAD)
+            version="unstable-$date.r${count}.$commit"
+            package_version="$date.r${count}.$commit"
+          fi
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$package_version" >> $GITHUB_OUTPUT
+          echo "PACKAGE_VERSION=$package_version" >> $GITHUB_ENV
+
+      - name: Get the filename
+        id: get_filename
+        run: |
+          export _NAME=$(jq ".[\"$GOOS-$GOARCH$GOARM$GOAMD64\"].friendlyName" -r < install/friendly-filenames.json)
+          echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
+          echo "BUNDLE_NAME=daed-$_NAME" >> $GITHUB_OUTPUT
+
+      - name: Install mips build dependencies
+        if: ${{ startsWith(matrix.goarch, 'mips') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mips64-linux-gnuabi64 gcc-mips64el-linux-gnuabi64 gcc-mips-linux-gnu gcc-mipsel-linux-gnu
+
+      - name: Download artifact - web
+        uses: actions/download-artifact@v3
+        with:
+          name: web
+          path: dist/
+
+      - name: make
+        run: |
+          mkdir -p ./bundled/
+          export VERSION=${{ steps.get_version.outputs.VERSION }}
+          export GOFLAGS="-trimpath -modcacherw"
+          export OUTPUT=bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }}
+          make
+          cp ./install/daed.service ./bundled/
+          curl -L -o ./bundled/geoip.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geoip.dat
+          curl -L -o ./bundled/geosite.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geosite.dat
+
+      - name: Smoking test
+        if: matrix.goarch == 'amd64'
+        run: ./bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }} --version
+
+      - name: Create binary ZIP archive and Signature
+        run: |
+          pushd bundled || exit 1
+          zip -9vr ../${{ steps.get_filename.outputs.BUNDLE_NAME }}.zip .
+          popd || exit 1
+          FILE=./${{ steps.get_filename.outputs.BUNDLE_NAME }}.zip
+          DGST=$FILE.dgst
+          md5sum        $FILE >>$DGST
+          shasum -a 1   $FILE >>$DGST
+          shasum -a 256 $FILE >>$DGST
+          shasum -a 512 $FILE >>$DGST
+
+      - name: Upload artifact - bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.get_filename.outputs.BUNDLE_NAME }}
+          path: bundled/*

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -1,5 +1,5 @@
 name: Pick Build (Preview)
-run-name: Build to '#${{ github.event.inputs.dae-core }} by @${{ github.actor }}'
+run-name: Build to '${{ github.event.inputs.wing }}-${{ github.event.inputs.dae-core }} by @${{ github.actor }}'
 
 on:
   workflow_dispatch:
@@ -31,6 +31,7 @@ jobs:
 
       - name: Download wing vendor
         run: |
+          git submodule deinit -f .
           git submodule update --init --recursive
           git checkout ${{ github.event.inputs.wing }}
           export GOMODCACHE="${PWD}"/go-mod

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -153,9 +153,7 @@ jobs:
 
       - name: Pick wing and dae-core
         run: |
-          git submodule update --init --recursive
-          cd wing && git reset --hard ${{ github.event.inputs.wing }} && go mod download -modcacherw
-          cd dae-core && git reset --hard ${{ github.event.inputs.dae-core }} && cd ../..
+          echo "y" | ./hack/checkout.sh core ${{ github.event.inputs.core }} wing ${{ github.event.inputs.wing }}
 
       - name: Get the version
         id: get_version
@@ -172,8 +170,8 @@ jobs:
             daed_commit=$(git rev-parse --short HEAD) && cd wing
             wing_commit=$(git rev-parse --short HEAD) && cd dae-core
             dae_core_commit=$(git rev-parse --short HEAD)
-            version="$frontier-$daed_commit.$wing_commit.$dae_core_commit"
-            package_version="$frontier-$daed_commit.$wing_commit.$dae_core_commit"
+            version="frontier-$daed_commit.$wing_commit.$dae_core_commit"
+            package_version="frontier-$daed_commit.$wing_commit.$dae_core_commit"
           fi
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
@@ -200,18 +198,19 @@ jobs:
           path: dist/
 
       - name: Change Makefile
-        if: ${{ !endsWith(matrix.goarch, '64') || startsWith(matrix.goarch, 'mips') }}
+        if: matrix.goarch != 'amd64' || matrix.goarch != 'arm64'
         run: |
           sed -i 's/buildmode=pie -//g' Makefile
         working-directory: wing
 
       - name: make
+        env:
+          SKIP_SUBMODULES: true
         run: |
           mkdir -p ./bundled/
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           export GOFLAGS="-trimpath -modcacherw"
           export OUTPUT=bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }}
-          sed -i '/^## Begin Git Submodules$/,/^## End Git Submodules$/d' Makefile
           make
           cp ./install/daed.service ./bundled/
           curl -L -o ./bundled/geoip.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geoip.dat

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [386, riscv64]
+        goarch: [386]
 
         include:
           # BEGIN Linux ARM 5 6 7 64
@@ -101,7 +101,16 @@ jobs:
             goarch: arm64
           - goos: linux
             goarch: arm
+            goarm: 5
+          - goos: linux
+            goarch: arm
+            goarm: 6
+          - goos: linux
+            goarch: arm
             goarm: 7
+          # END Linux ARM 5 6 7
+
+          # BEGIN Linux AMD64 v1 v2 v3
           - goos: linux
             goarch: amd64
             goamd64: v1
@@ -113,6 +122,25 @@ jobs:
             goamd64: v3
           # END Linux AMD64 v1 v2 v3
 
+          # BEGIN Linux mips
+          - goos: linux
+            goarch: mips64
+            cgo_enabled: 1
+            cc: mips64-linux-gnuabi64-gcc
+          - goos: linux
+            goarch: mips64le
+            cgo_enabled: 1
+            cc: mips64el-linux-gnuabi64-gcc
+          - goos: linux
+            goarch: mipsle
+            cgo_enabled: 1
+            cc: mipsel-linux-gnu-gcc
+          - goos: linux
+            goarch: mips
+            cgo_enabled: 1
+            cc: mips-linux-gnu-gcc
+          # END Linux mips
+
       fail-fast: false
 
     env:
@@ -122,7 +150,6 @@ jobs:
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
       CC: ${{ matrix.cc }}
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - uses: actions/checkout@v3
@@ -155,6 +182,12 @@ jobs:
           echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
           echo "BUNDLE_NAME=daed-$_NAME" >> $GITHUB_OUTPUT
 
+      - name: Install mips build dependencies
+        if: ${{ startsWith(matrix.goarch, 'mips') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mips64-linux-gnuabi64 gcc-mips64el-linux-gnuabi64 gcc-mips-linux-gnu gcc-mipsel-linux-gnu
+
       - name: Download artifact - web
         uses: actions/download-artifact@v3
         with:
@@ -168,7 +201,7 @@ jobs:
           cd dae-core && git reset --hard remotes/origin/${{ github.event.inputs.dae-core }} && cd ../..
 
       - name: Change Makefile
-        if: ${{ !endsWith(matrix.goarch, '64') }}
+        if: ${{ !endsWith(matrix.goarch, '64') || startsWith(matrix.goarch, 'mips') }}
         run: |
           sed -i 's/buildmode=pie -//g' Makefile
         working-directory: wing

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -1,27 +1,23 @@
 name: Pick Build (Preview)
-run-name: Build to '${{ github.event.inputs.wing }}-${{ github.event.inputs.dae-core }} by @${{ github.actor }}'
+run-name: 'Build to ${{ github.event.inputs.daed }}-${{ github.event.inputs.wing }}-${{ github.event.inputs.dae-core }}'
 
 on:
   workflow_dispatch:
     inputs:
-      wing:
-        description: 'Commit hash or branch for wing'
+      daed:
+        description: 'Commit ID or branch for daed'
         required: false
-        default: 'main' # Default to latest commit on main branch
+        default: 'main'
+      wing:
+        description: 'Commit ID or branch for wing'
+        required: false
+        default: 'main'
       dae-core:
-        description: 'Commit hash or branch for dae-core'
-        required: true
+        description: 'Commit ID or branch for dae-core'
+        required: false
+        default: 'main'
 
 jobs:
-  context:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
-
   checkout-full-src:
     runs-on: ubuntu-latest
     steps:
@@ -29,21 +25,32 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Pick daed
+        run: |
+          git remote update
+          git checkout ${{ github.event.inputs.daed }}
+
       - name: Download wing vendor
         run: |
-          git submodule deinit -f .
+          git remote update
           git submodule update --init --recursive
           git checkout ${{ github.event.inputs.wing }}
           export GOMODCACHE="${PWD}"/go-mod
           go mod download -modcacherw
-          cd dae-core && git checkout ${{ github.event.inputs.dae-core }} && go mod download -modcacherw && cd ..
+          cd dae-core && git merge origin/${{ github.event.inputs.dae-core }} && go mod download -modcacherw && cd ..
           find "$GOMODCACHE" -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
           sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
         working-directory: wing
 
       - name: Create full source ZIP archive and Signature
         run: |
-          zip -9vr daed-full-src.zip . -x .git/\*
+          zip -9vr daed-full-src.zip .
+          FILE=./daed-full-src.zip
+          DGST=$FILE.dgst
+          md5sum        $FILE >>$DGST
+          shasum -a 1   $FILE >>$DGST
+          shasum -a 256 $FILE >>$DGST
+          shasum -a 512 $FILE >>$DGST
 
       - name: Upload artifact - full source
         uses: actions/upload-artifact@v3
@@ -55,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.daed }}
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
         with:
@@ -83,30 +93,39 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [arm64, amd64]
+        goarch: [386, riscv64]
+
         include:
-          # BEGIN Linux ARM 5 6 7
+          # BEGIN Linux ARM 5 6 7 64
+          - goos: linux
+            goarch: arm64
           - goos: linux
             goarch: arm
             goarm: 7
           - goos: linux
-            goarch: arm
-            goarm: 6
+            goarch: amd64
+            goamd64: v1
           - goos: linux
-            goarch: arm
-            goarm: 5
-          # END Linux ARM 5 6 7
+            goarch: amd64
+            goamd64: v2
+          - goos: linux
+            goarch: amd64
+            goamd64: v3
+          # END Linux AMD64 v1 v2 v3
+
       fail-fast: false
 
     env:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
+      GOAMD64: ${{ matrix.goamd64 }}
+      CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
+      CC: ${{ matrix.cc }}
+      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Get the version
         id: get_version
@@ -136,17 +155,23 @@ jobs:
           echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
           echo "BUNDLE_NAME=daed-$_NAME" >> $GITHUB_OUTPUT
 
-      - name: Install mips build dependencies
-        if: ${{ startsWith(matrix.goarch, 'mips') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-mips64-linux-gnuabi64 gcc-mips64el-linux-gnuabi64 gcc-mips-linux-gnu gcc-mipsel-linux-gnu
-
       - name: Download artifact - web
         uses: actions/download-artifact@v3
         with:
           name: web
           path: dist/
+
+      - name: Pick wing and dae-core
+        run: |
+          git submodule update --init --recursive
+          cd wing && git reset --hard remotes/origin/${{ github.event.inputs.wing }}
+          cd dae-core && git reset --hard remotes/origin/${{ github.event.inputs.dae-core }} && cd ../..
+
+      - name: Change Makefile
+        if: ${{ !endsWith(matrix.goarch, '64') }}
+        run: |
+          sed -i 's/buildmode=pie -//g' Makefile
+        working-directory: wing
 
       - name: make
         run: |
@@ -154,6 +179,7 @@ jobs:
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           export GOFLAGS="-trimpath -modcacherw"
           export OUTPUT=bundled/${{ steps.get_filename.outputs.BUNDLE_NAME }}
+          sed -i '/^## Begin Git Submodules$/,/^## End Git Submodules$/d' Makefile
           make
           cp ./install/daed.service ./bundled/
           curl -L -o ./bundled/geoip.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geoip.dat

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Pick wing and dae-core
         run: |
-          echo "y" | ./hack/checkout.sh core ${{ github.event.inputs.core }} wing ${{ github.event.inputs.wing }}
+          echo "y" | ./hack/checkout.sh core ${{ github.event.inputs.dae-core }} wing ${{ github.event.inputs.wing }}
 
       - name: Get the version
         id: get_version
@@ -198,7 +198,7 @@ jobs:
           path: dist/
 
       - name: Change Makefile
-        if: matrix.goarch != 'amd64' || matrix.goarch != 'arm64'
+        if: matrix.goarch != 'amd64' && matrix.goarch != 'arm64'
         run: |
           sed -i 's/buildmode=pie -//g' Makefile
         working-directory: wing

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ clean:
 -include .gitmodules.d.mk
 
 $(submodule_ready): .gitmodules.d.mk
+ifdef SKIP_SUBMODULES
+	@echo "Skipping submodule update"
+else
 	git submodule update --init --recursive -- "$$(dirname $@)" && \
 	touch $@
+endif
 
 submodule submodules: $(submodule_ready)
 	@if [ -z "$(submodule_ready)" ]; then \


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https:github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
作为 core， dae 用户可以很方便的提前体验到令人激动的新功能，而 daed 要等待更久的链路同步时间: dae ->  dae-wing -> daed

这让使用daed的我们黯然神伤，我们也想要体验最新的功能 ！

虽然我们已经有了 [hack/checkout.sh](https:github.com/daeuniverse/daed/blob/main/hack/checkout.sh) 可以挑选分支进行本地构建。但是这对用户来说仍需要一定的成本，比如机器性能赢弱的编译可能会比较困难。

此 PR 添加了一个需手动触发的 workflow ，允许指定 commit id 或分支名进行构建，方便用户在daed 上提前体验 dae 令人激动的新功能

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https:github.com/daeuniverse/daed

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. --