### PR TITLE
ci(pick): fix build error when daed is not main

### DIFF
--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -153,7 +153,9 @@ jobs:
 
       - name: Pick wing and dae-core
         run: |
-          echo "y" | ./hack/checkout.sh core ${{ github.event.inputs.dae-core }} wing ${{ github.event.inputs.wing }}
+          git submodule update --init --recursive
+          cd wing && git reset --hard ${{ github.event.inputs.wing }} && go mod download -modcacherw
+          cd dae-core && git reset --hard ${{ github.event.inputs.dae-core }} && cd ../..
 
       - name: Get the version
         id: get_version


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
Because [hack/checkout.sh](https://github.com/wanlce/daed/blob/main/hack/checkout.sh) modifies wing and core, but not daed,`pick_build workflow` supports modification of daed, wing and dae at the same time, so it can be used simply and directly    

![image](https://github.com/daeuniverse/daed/assets/55907021/126d29b5-4909-43b5-88de-18411487c79b)

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https:github.com/daeuniverse/daed

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. --> 