### PR TITLE
chore: remove BUILD_ARGS in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,6 @@ jobs:
           # BEGIN Linux ARM 5 6 7 64
           - goos: linux
             goarch: arm64
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -99,15 +98,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
 
           # BEGIN Linux mips
@@ -137,7 +133,6 @@ jobs:
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
       CC: ${{ matrix.cc }}
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pick-build.yml
+++ b/.github/workflows/pick-build.yml
@@ -199,12 +199,6 @@ jobs:
           name: web
           path: dist/
 
-      - name: Change Makefile
-        if: matrix.goarch != 'amd64' && matrix.goarch != 'arm64'
-        run: |
-          sed -i 's/buildmode=pie -//g' Makefile
-        working-directory: wing
-
       - name: make
         env:
           SKIP_SUBMODULES: true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -74,7 +74,6 @@ jobs:
           # BEGIN Linux ARM 5 6 7 64
           - goos: linux
             goarch: arm64
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -90,15 +89,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
 
           # BEGIN Linux mips
@@ -128,7 +124,6 @@ jobs:
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
       CC: ${{ matrix.cc }}
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
           # BEGIN Linux ARM 5 6 7 64
           - goos: linux
             goarch: arm64
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -93,15 +92,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
 
           # BEGIN Linux mips
@@ -131,7 +127,6 @@ jobs:
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: ${{ matrix.cgo_enabled || 0 }}
       CC: ${{ matrix.cc }}
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Since we have merged https://github.com/daeuniverse/daed/pull/233. There is no need to define `pie` in `BUILD_ARGS` explicitly.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
