### PR TITLE
docs/getting-started.md: add archlinux installation guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,33 @@ sudo systemctl start daed
 sudo systemctl enable daed
 ``````
 
+### Arch Linux
+
+Releases are available in <https://github.com/daeuniverse/daed/releases> or the following command installs the latest version of the precompiled installation package consistent with your current system architecture
+
+#### AUR
+##### Latest Release
+``````shell
+[yay/paru] -S daed
+``````
+##### Latest Git Version
+``````shell
+[yay/paru] -S daed-git
+``````
+
+#### archlinuxcn
+##### Latest Release (Optimized for x86-64 v3)
+``````shell
+sudo pacman -S daed-bin-x64-v3
+``````
+##### Latest Release (General x86-64 or aarch64)
+``````shell
+sudo pacman -S daed
+``````
+##### Latest Git Version
+``````shell
+sudo pacman -S daed-git
+``````
 ### Docker (Experimental)
 
 Pre-built Docker images are available in `ghcr.io/daeuniverse/daed`. The command below pulls and runs the latest image


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

No installation guide of daed on Arch Linux in ```docs/getting-started.md```.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full Changelogs

- Add installation guide of daed on Arch Linux in ```docs/getting-started.md```.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
