### PR TITLE
fix(v2ray): vmess websocket path emty

### DIFF
--- a/src/components/ConfigureNodeFormModal/V2rayForm.tsx
+++ b/src/components/ConfigureNodeFormModal/V2rayForm.tsx
@@ -62,6 +62,8 @@ export const V2rayForm = ({ onLinkGeneration }: { onLinkGeneration: (link: strin
 
       switch (body.net) {
         case 'ws':
+          // 不做任何操作，直接跳过
+          break;
         case 'h2':
         case 'grpc':
         case 'kcp':


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes [[Bug Report] vmess 使用websocket时不支持配置Path参数](https://github.com/daeuniverse/dae-wing/issues/167)

### Test Result

<!--- Attach test result here. -->
