### PR TITLE
docs: update archlinuxcn package name & add AVX2 package to AUR

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,28 +104,45 @@ sudo systemctl enable daed
 Releases are available in <https://github.com/daeuniverse/daed/releases> or the following command installs the latest version of the precompiled installation package consistent with your current system architecture
 
 #### AUR
-##### Latest Release
+
+##### Latest Release (Optimized Binary for x86-64 v3 / AVX2)
+
+``````shell
+[yay/paru] -S daed-avx2-bin
+``````
+
+##### Latest Release (General x86-64 or aarch64)
+
 ``````shell
 [yay/paru] -S daed
 ``````
+
 ##### Latest Git Version
+
 ``````shell
 [yay/paru] -S daed-git
 ``````
 
 #### archlinuxcn
-##### Latest Release (Optimized for x86-64 v3)
+
+##### Latest Release (Optimized Binary for x86-64 v3 / AVX2)
+
 ``````shell
-sudo pacman -S daed-bin-x64-v3
+sudo pacman -S daed-avx2-bin
 ``````
+
 ##### Latest Release (General x86-64 or aarch64)
+
 ``````shell
 sudo pacman -S daed
 ``````
+
 ##### Latest Git Version
+
 ``````shell
 sudo pacman -S daed-git
 ``````
+
 ### Docker (Experimental)
 
 Pre-built Docker images are available in `ghcr.io/daeuniverse/daed`, `quay.io/daeuniverse/daed` and `daeuniverse/daed`. 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

The original package name `daed-bin-x64-v3` is ill-formed, which makes it removed from AUR. Therefore, it has been renamed to `daed-avx2-bin`.

Related commit: https://github.com/archlinuxcn/repo/commit/219e513c86bb762ec13a62c0f000f9073326c684

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/daed

### Full Changelogs

- Update package name of the AVX2-optimized binary package in archlinuxcn section of installation guide
- Add AVX2-optimized binary package to AUR section in installation guide
- Format the Arch Linux section in installation guide

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
