### PR TITLE
fix(web): drop unused GroupAddNodes variable

### DIFF
--- a/apps/web/src/schemas/gql/graphql.ts
+++ b/apps/web/src/schemas/gql/graphql.ts
@@ -2148,11 +2148,6 @@ export const GroupAddNodesDocument = {
             },
           },
         },
-        {
-          kind: 'VariableDefinition',
-          variable: { kind: 'Variable', name: { kind: 'Name', value: 'nameFilterRegex' } },
-          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
-        },
       ],
       selectionSet: {
         kind: 'SelectionSet',


### PR DESCRIPTION
## Summary

This PR fixes a generated GraphQL document mismatch in `GroupAddNodes`.

`GroupAddNodesDocument` incorrectly includes an unused `$nameFilterRegex` variable, while the actual mutation only uses:

- `id`
- `nodeIDs`

This causes GraphQL validation errors such as:

`Variable "$nameFilterRegex" is never used in operation "GroupAddNodes".`

## What changed

- remove the unused `nameFilterRegex` variable definition from `GroupAddNodesDocument`

## Scope

- frontend only
- generated GraphQL document only
- no backend behavior changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unused variable definition from a mutation, improving API consistency and reducing potential confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->