### PR TITLE
feat(web): add runtime traffic overview and node latency displays

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wing"]
 	path = wing
-	url = https://github.com/ksong008/dae-wing
+	url = https://github.com/daeuniverse/dae-wing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wing"]
 	path = wing
-	url = https://github.com/daeuniverse/dae-wing
+	url = https://github.com/ksong008/dae-wing

--- a/apps/web/src/apis/mutation.ts
+++ b/apps/web/src/apis/mutation.ts
@@ -7,6 +7,7 @@ import {
   QUERY_KEY_DNS,
   QUERY_KEY_GENERAL,
   QUERY_KEY_GROUP,
+  QUERY_KEY_NODE_LATENCY,
   QUERY_KEY_NODE,
   QUERY_KEY_ROUTING,
   QUERY_KEY_SUBSCRIPTION,
@@ -804,6 +805,7 @@ export interface NodeLatencyProbeResult {
 
 export function useTestNodeLatenciesMutation() {
   const gqlClient = useGQLQueryClient()
+  const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (ids?: string[]) => {
@@ -826,6 +828,9 @@ export function useTestNodeLatenciesMutation() {
       )
 
       return data.testNodeLatencies
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_NODE_LATENCY })
     },
   })
 }

--- a/apps/web/src/apis/mutation.ts
+++ b/apps/web/src/apis/mutation.ts
@@ -794,6 +794,42 @@ export function useUpdateSubscriptionsMutation() {
   })
 }
 
+export interface NodeLatencyProbeResult {
+  id: string
+  latencyMs?: number | null
+  alive: boolean
+  testedAt: string
+  message?: string | null
+}
+
+export function useTestNodeLatenciesMutation() {
+  const gqlClient = useGQLQueryClient()
+
+  return useMutation({
+    mutationFn: async (ids?: string[]) => {
+      const data = await gqlClient.request<
+        { testNodeLatencies: NodeLatencyProbeResult[] },
+        { ids?: string[] }
+      >(
+        `
+          mutation TestNodeLatencies($ids: [ID!]) {
+            testNodeLatencies(ids: $ids) {
+              id
+              latencyMs
+              alive
+              testedAt
+              message
+            }
+          }
+        `,
+        ids && ids.length > 0 ? { ids } : {},
+      )
+
+      return data.testNodeLatencies
+    },
+  })
+}
+
 export function useRemoveSubscriptionsMutation() {
   const gqlClient = useGQLQueryClient()
   const queryClient = useQueryClient()

--- a/apps/web/src/apis/query.ts
+++ b/apps/web/src/apis/query.ts
@@ -6,6 +6,7 @@ import {
   QUERY_KEY_DNS,
   QUERY_KEY_GENERAL,
   QUERY_KEY_GROUP,
+  QUERY_KEY_NODE_LATENCY,
   QUERY_KEY_NODE,
   QUERY_KEY_ROUTING,
   QUERY_KEY_STORAGE,
@@ -15,6 +16,7 @@ import {
 } from '~/constants'
 import { useGQLQueryClient } from '~/contexts'
 import { graphql } from '~/schemas/gql'
+import type { NodeLatencyProbeResult } from './mutation'
 
 export function getModeRequest(gqlClient: GQLClientInterface) {
   return async () => {
@@ -204,6 +206,34 @@ export function useTrafficOverviewQuery(windowSec: number, maxPoints: number) {
     },
     placeholderData: (previousData) => previousData,
     refetchInterval: 500,
+    refetchIntervalInBackground: true,
+  })
+}
+
+export function useNodeLatenciesQuery(refetchIntervalMs: number) {
+  const gqlClient = useGQLQueryClient()
+
+  return useQuery({
+    queryKey: QUERY_KEY_NODE_LATENCY,
+    queryFn: async () => {
+      const data = await gqlClient.request<{ nodeLatencies: NodeLatencyProbeResult[] }>(
+        `
+          query NodeLatencies {
+            nodeLatencies {
+              id
+              latencyMs
+              alive
+              testedAt
+              message
+            }
+          }
+        `,
+      )
+
+      return data.nodeLatencies
+    },
+    placeholderData: (previousData) => previousData,
+    refetchInterval: refetchIntervalMs,
     refetchIntervalInBackground: true,
   })
 }

--- a/apps/web/src/apis/query.ts
+++ b/apps/web/src/apis/query.ts
@@ -10,6 +10,7 @@ import {
   QUERY_KEY_ROUTING,
   QUERY_KEY_STORAGE,
   QUERY_KEY_SUBSCRIPTION,
+  QUERY_KEY_TRAFFIC,
   QUERY_KEY_USER,
 } from '~/constants'
 import { useGQLQueryClient } from '~/contexts'
@@ -145,6 +146,65 @@ export function useGeneralQuery() {
           up: true,
         },
       ),
+  })
+}
+
+export interface TrafficOverviewQueryData {
+  updatedAt: string
+  uploadRate: number
+  downloadRate: number
+  uploadTotal: string
+  downloadTotal: string
+  activeConnections: number
+  udpSessions: number
+  samples: Array<{
+    timestamp: string
+    uploadRate: number
+    downloadRate: number
+  }>
+}
+
+export function useTrafficOverviewQuery(windowSec: number, maxPoints: number) {
+  const gqlClient = useGQLQueryClient()
+
+  return useQuery({
+    queryKey: [...QUERY_KEY_TRAFFIC, windowSec, maxPoints],
+    queryFn: async () => {
+      const data = await gqlClient.request<
+        { general: { runtimeOverview: TrafficOverviewQueryData } },
+        { windowSec: number; maxPoints: number }
+      >(
+        `
+          query TrafficOverview($windowSec: Int!, $maxPoints: Int!) {
+            general {
+              runtimeOverview(windowSec: $windowSec, maxPoints: $maxPoints) {
+                updatedAt
+                uploadRate
+                downloadRate
+                uploadTotal
+                downloadTotal
+                activeConnections
+                udpSessions
+                samples {
+                  timestamp
+                  uploadRate
+                  downloadRate
+                }
+              }
+            }
+          }
+        `,
+        {
+          windowSec,
+          maxPoints,
+        },
+      )
+
+      return data.general.runtimeOverview
+    },
+    placeholderData: (previousData) => previousData,
+    refetchInterval: 1000,
+    refetchIntervalInBackground: true,
   })
 }
 

--- a/apps/web/src/apis/query.ts
+++ b/apps/web/src/apis/query.ts
@@ -203,7 +203,7 @@ export function useTrafficOverviewQuery(windowSec: number, maxPoints: number) {
       return data.general.runtimeOverview
     },
     placeholderData: (previousData) => previousData,
-    refetchInterval: 1000,
+    refetchInterval: 500,
     refetchIntervalInBackground: true,
   })
 }

--- a/apps/web/src/apis/query.ts
+++ b/apps/web/src/apis/query.ts
@@ -168,6 +168,7 @@ export interface TrafficOverviewQueryData {
 
 export function useTrafficOverviewQuery(windowSec: number, maxPoints: number) {
   const gqlClient = useGQLQueryClient()
+  const refetchInterval = Math.max(500, Math.min(5_000, Math.round(windowSec / 60) * 500))
 
   return useQuery({
     queryKey: [...QUERY_KEY_TRAFFIC, windowSec, maxPoints],
@@ -205,13 +206,13 @@ export function useTrafficOverviewQuery(windowSec: number, maxPoints: number) {
       return data.general.runtimeOverview
     },
     placeholderData: (previousData) => previousData,
-    refetchInterval: 500,
-    refetchIntervalInBackground: true,
+    refetchInterval,
   })
 }
 
 export function useNodeLatenciesQuery(refetchIntervalMs: number) {
   const gqlClient = useGQLQueryClient()
+  const safeInterval = Math.max(1_000, refetchIntervalMs)
 
   return useQuery({
     queryKey: QUERY_KEY_NODE_LATENCY,
@@ -233,7 +234,7 @@ export function useNodeLatenciesQuery(refetchIntervalMs: number) {
       return data.nodeLatencies
     },
     placeholderData: (previousData) => previousData,
-    refetchInterval: refetchIntervalMs,
+    refetchInterval: safeInterval,
     refetchIntervalInBackground: true,
   })
 }

--- a/apps/web/src/components/DraggableResourceBadge.tsx
+++ b/apps/web/src/components/DraggableResourceBadge.tsx
@@ -10,12 +10,14 @@ export function DraggableResourceBadge({
   id,
   index,
   name,
+  meta,
   onRemove,
   children,
 }: {
   id: string
   index: number
   name: string
+  meta?: React.ReactNode
   onRemove?: () => void
   children?: React.ReactNode
 }) {
@@ -41,6 +43,8 @@ export function DraggableResourceBadge({
 
       {/* Name */}
       <span className="text-xs font-medium truncate flex-1">{name}</span>
+
+      {meta && <span className="shrink-0 text-[10px] font-medium text-primary">{meta}</span>}
 
       {/* Remove button */}
       {onRemove && (

--- a/apps/web/src/components/GroupResourcePickerModal.tsx
+++ b/apps/web/src/components/GroupResourcePickerModal.tsx
@@ -163,7 +163,14 @@ function SelectionDialog({
                         <div className="flex min-w-0 items-center gap-2">
                           <p className="max-w-[20rem] truncate text-sm font-medium">{item.title}</p>
                           {item.meta && (
-                            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                            <span
+                              className={cn(
+                                'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium',
+                                item.metaTone === 'primary'
+                                  ? 'bg-primary/10 text-primary'
+                                  : 'bg-muted text-muted-foreground',
+                              )}
+                            >
                               {item.meta}
                             </span>
                           )}
@@ -180,7 +187,16 @@ function SelectionDialog({
                           </div>
 
                           {item.description && <p className="mt-1 truncate text-xs text-muted-foreground">{item.description}</p>}
-                          {item.meta && <p className="mt-1 text-[11px] text-muted-foreground">{item.meta}</p>}
+                          {item.meta && (
+                            <p
+                              className={cn(
+                                'mt-1 text-[11px]',
+                                item.metaTone === 'primary' ? 'text-primary' : 'text-muted-foreground',
+                              )}
+                            >
+                              {item.meta}
+                            </p>
+                          )}
                         </div>
                       )}
                     </div>

--- a/apps/web/src/components/SortableGroupContent.tsx
+++ b/apps/web/src/components/SortableGroupContent.tsx
@@ -37,6 +37,13 @@ interface Subscription {
   tag?: string | null
 }
 
+interface NodeLatencyProbeResult {
+  latencyMs?: number | null
+  alive: boolean
+  testedAt: string
+  message?: string | null
+}
+
 function GroupDropZone({
   droppableId,
   type,
@@ -139,6 +146,7 @@ export function SortableGroupContent({
   groupId,
   nodes,
   subscriptions,
+  nodeLatencies,
   allSubscriptions,
   autoExpandValue,
   collapsed,
@@ -151,6 +159,7 @@ export function SortableGroupContent({
   groupId: string
   nodes: GroupNode[]
   subscriptions: GroupSubscription[]
+  nodeLatencies?: Record<string, NodeLatencyProbeResult>
   allSubscriptions?: Subscription[]
   autoExpandValue?: string
   collapsed?: boolean
@@ -240,6 +249,7 @@ export function SortableGroupContent({
             name={tag || name}
             protocol={protocol}
             address={address}
+            meta={formatLatencyMeta(nodeLatencies?.[nodeId])}
             onRemove={() => onDelNode(nodeId)}
           >
             {subscriptionID && allSubscriptions?.find((subscription) => subscription.id === subscriptionID)?.tag}
@@ -287,4 +297,17 @@ export function SortableGroupContent({
       </GroupDropZone>
     </div>
   )
+}
+
+function formatLatencyMeta(result?: NodeLatencyProbeResult) {
+  if (!result) {
+    return undefined
+  }
+  if (typeof result.latencyMs === 'number') {
+    return `${result.latencyMs}ms`
+  }
+  if (result.message) {
+    return result.message === 'no latency result' ? 'N/A' : 'Fail'
+  }
+  return 'N/A'
 }

--- a/apps/web/src/components/SortableGroupContent.tsx
+++ b/apps/web/src/components/SortableGroupContent.tsx
@@ -1,3 +1,4 @@
+import type { NodeLatencyProbeResult } from '~/apis'
 import { Droppable } from '@hello-pangea/dnd'
 import { ChevronDown, Plus } from 'lucide-react'
 import { useStore } from '@nanostores/react'
@@ -6,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { SortableResourceBadge } from '~/components/SortableResourceBadge'
 import { Button } from '~/components/ui/button'
 import { cn } from '~/lib/utils'
+import { formatLatencyLabel } from '~/utils/latency'
 import { groupSortOrdersAtom } from '~/store'
 
 interface GroupNode {
@@ -35,13 +37,6 @@ interface GroupSubscription {
 interface Subscription {
   id: string
   tag?: string | null
-}
-
-interface NodeLatencyProbeResult {
-  latencyMs?: number | null
-  alive: boolean
-  testedAt: string
-  message?: string | null
 }
 
 function GroupDropZone({
@@ -249,7 +244,7 @@ export function SortableGroupContent({
             name={tag || name}
             protocol={protocol}
             address={address}
-            meta={formatLatencyMeta(nodeLatencies?.[nodeId])}
+            meta={formatLatencyLabel(nodeLatencies?.[nodeId], t)}
             onRemove={() => onDelNode(nodeId)}
           >
             {subscriptionID && allSubscriptions?.find((subscription) => subscription.id === subscriptionID)?.tag}
@@ -297,17 +292,4 @@ export function SortableGroupContent({
       </GroupDropZone>
     </div>
   )
-}
-
-function formatLatencyMeta(result?: NodeLatencyProbeResult) {
-  if (!result) {
-    return undefined
-  }
-  if (typeof result.latencyMs === 'number') {
-    return `${result.latencyMs}ms`
-  }
-  if (result.message) {
-    return result.message === 'no latency result' ? 'N/A' : 'Fail'
-  }
-  return 'N/A'
 }

--- a/apps/web/src/components/SortableResourceBadge.tsx
+++ b/apps/web/src/components/SortableResourceBadge.tsx
@@ -12,6 +12,7 @@ export function SortableResourceBadge({
   name,
   protocol,
   address,
+  meta,
   onRemove,
   children,
 }: {
@@ -20,6 +21,7 @@ export function SortableResourceBadge({
   name: string
   protocol?: string | null
   address?: string | null
+  meta?: React.ReactNode
   onRemove?: () => void
   children?: React.ReactNode
 }) {
@@ -55,6 +57,8 @@ export function SortableResourceBadge({
         <span className="text-xs font-medium truncate block">{name}</span>
         {address && <span className="text-[10px] text-muted-foreground truncate block mt-0.5">{address}</span>}
       </div>
+
+      {meta && <span className="shrink-0 text-[10px] font-medium text-primary">{meta}</span>}
 
       {/* Remove button */}
       {onRemove && (

--- a/apps/web/src/constants/misc.ts
+++ b/apps/web/src/constants/misc.ts
@@ -100,6 +100,7 @@ export const QUERY_KEY_DNS = ['dns']
 export const QUERY_KEY_GROUP = ['group']
 export const QUERY_KEY_STORAGE = ['storage']
 export const QUERY_KEY_TRAFFIC = ['traffic']
+export const QUERY_KEY_NODE_LATENCY = ['nodeLatency']
 
 export enum DraggableResourceType {
   node = 'node',

--- a/apps/web/src/constants/misc.ts
+++ b/apps/web/src/constants/misc.ts
@@ -99,6 +99,7 @@ export const QUERY_KEY_ROUTING = ['routing']
 export const QUERY_KEY_DNS = ['dns']
 export const QUERY_KEY_GROUP = ['group']
 export const QUERY_KEY_STORAGE = ['storage']
+export const QUERY_KEY_TRAFFIC = ['traffic']
 
 export enum DraggableResourceType {
   node = 'node',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -64,6 +64,7 @@
     "switchLanguage": "Switch Language",
     "switchRunning": "Switch Running",
     "switchTheme": "Switch Theme",
+    "testLatency": "Test Latency",
     "update": "Update",
     "updateAll": "Update All",
     "viewDetails": "View Details",
@@ -239,6 +240,13 @@
   "ip": "IP Address",
   "lanInterface": "LAN Interface",
   "lanNatDirect": "LAN NAT Direct connection",
+  "latency": {
+    "label": "Latency",
+    "lastTested": "Last tested at {{ time }}",
+    "testAllNodes": "Test all node latencies",
+    "nodesMeasured": "{{ count }} nodes measured",
+    "unavailable": "Unavailable"
+  },
   "link": "Link",
   "logLevel": "Log Level",
   "login account": "Login via username & password",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -263,6 +263,7 @@
     "connectionsUnit": "conn",
     "sessionsUnit": "sessions",
     "ranges": {
+      "1m": "1m",
       "10m": "10m",
       "30m": "30m",
       "1h": "1h"

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -244,7 +244,9 @@
     "label": "Latency",
     "lastTested": "Last tested at {{ time }}",
     "testAllNodes": "Test all node latencies",
+    "testAllNodesWithStatus": "Test all node latencies · Last tested at {{ time }} · {{ count }} nodes measured",
     "nodesMeasured": "{{ count }} nodes measured",
+    "failed": "Failed",
     "unavailable": "Unavailable"
   },
   "link": "Link",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -246,6 +246,28 @@
   "name": "Name",
   "node": "Node",
   "node connectivity check": "Node Connectivity Check",
+  "trafficOverview": {
+    "title": "Traffic Statistics",
+    "description": "Rolling uplink and downlink overview with a switchable time window.",
+    "uploadChart": "Uplink Traffic",
+    "downloadChart": "Downlink Traffic",
+    "uploadLegend": "Upload",
+    "downloadLegend": "Download",
+    "liveWindow": "Auto-scrolling live window",
+    "uploadSpeed": "Upload Speed",
+    "downloadSpeed": "Download Speed",
+    "activeConnections": "Active Connections",
+    "totalUpload": "Total Upload",
+    "totalDownload": "Total Download",
+    "udpSessions": "UDP Sessions",
+    "connectionsUnit": "conn",
+    "sessionsUnit": "sessions",
+    "ranges": {
+      "10m": "10m",
+      "30m": "30m",
+      "1h": "1h"
+    }
+  },
   "notifications": {
     "login succeeded": "Login Succeeded",
     "success": "Success"

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -64,6 +64,7 @@
     "switchLanguage": "切换语言",
     "switchRunning": "运行开关",
     "switchTheme": "切换主题",
+    "testLatency": "测试延迟",
     "update": "更新",
     "updateAll": "更新全部",
     "viewDetails": "查看详情",
@@ -239,6 +240,13 @@
   "ip": "IP 地址",
   "lanInterface": "LAN 接口",
   "lanNatDirect": "LAN NAT 直连",
+  "latency": {
+    "label": "延迟",
+    "lastTested": "最近测速时间 {{ time }}",
+    "testAllNodes": "测试所有节点延迟",
+    "nodesMeasured": "已测速 {{ count }} 个节点",
+    "unavailable": "不可用"
+  },
   "link": "链接",
   "logLevel": "日志等级",
   "login account": "使用帐号密码登录",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -263,6 +263,7 @@
     "connectionsUnit": "连接",
     "sessionsUnit": "会话",
     "ranges": {
+      "1m": "1 分钟",
       "10m": "10 分钟",
       "30m": "30 分钟",
       "1h": "1 小时"

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -244,7 +244,9 @@
     "label": "延迟",
     "lastTested": "最近测速时间 {{ time }}",
     "testAllNodes": "测试所有节点延迟",
+    "testAllNodesWithStatus": "测试所有节点延迟 · 最近测速时间 {{ time }} · 已测速 {{ count }} 个节点",
     "nodesMeasured": "已测速 {{ count }} 个节点",
+    "failed": "失败",
     "unavailable": "不可用"
   },
   "link": "链接",

--- a/apps/web/src/i18n/locales/zh-Hans.json
+++ b/apps/web/src/i18n/locales/zh-Hans.json
@@ -246,6 +246,28 @@
   "name": "名字",
   "node": "节点",
   "node connectivity check": "节点连通性检测",
+  "trafficOverview": {
+    "title": "流量统计",
+    "description": "实时滚动展示上下行流量，并支持切换时间窗口。",
+    "uploadChart": "上行流量",
+    "downloadChart": "下行流量",
+    "uploadLegend": "上传",
+    "downloadLegend": "下载",
+    "liveWindow": "自动滚动的实时窗口",
+    "uploadSpeed": "上传速度",
+    "downloadSpeed": "下载速度",
+    "activeConnections": "活跃连接",
+    "totalUpload": "累计上传",
+    "totalDownload": "累计下载",
+    "udpSessions": "UDP 会话",
+    "connectionsUnit": "连接",
+    "sessionsUnit": "会话",
+    "ranges": {
+      "10m": "10 分钟",
+      "30m": "30 分钟",
+      "1h": "1 小时"
+    }
+  },
   "notifications": {
     "login succeeded": "登录成功",
     "success": "成功"

--- a/apps/web/src/pages/Orchestrate/Group.tsx
+++ b/apps/web/src/pages/Orchestrate/Group.tsx
@@ -156,6 +156,7 @@ export function GroupResource({
           meta: [t('groupPicker.manualNode'), formatLatencyMeta(nodeLatencies?.[node.id])]
             .filter(Boolean)
             .join(' · '),
+          metaTone: nodeLatencies?.[node.id] ? 'primary' : 'default',
           badge: node.protocol || undefined,
           keywords: [node.name, node.tag, node.address, node.protocol].filter(Boolean) as string[],
         }
@@ -179,6 +180,7 @@ export function GroupResource({
             meta: [t('groupPicker.fromSubscription', { name: subscriptionName }), formatLatencyMeta(nodeLatencies?.[node.id])]
               .filter(Boolean)
               .join(' · '),
+            metaTone: nodeLatencies?.[node.id] ? 'primary' : 'default',
             badge: node.protocol || undefined,
             keywords: [node.name, node.tag, node.address, node.protocol, subscriptionName].filter(Boolean) as string[],
           }

--- a/apps/web/src/pages/Orchestrate/Group.tsx
+++ b/apps/web/src/pages/Orchestrate/Group.tsx
@@ -1,4 +1,5 @@
 import type { GroupFormModalRef } from '~/components/GroupFormModal'
+import type { NodeLatencyProbeResult } from '~/apis'
 import type { DraggingResource } from '~/constants'
 import type { GroupsQuery, NodesQuery, SubscriptionsQuery } from '~/schemas/gql/graphql'
 import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd'
@@ -44,11 +45,13 @@ export function GroupResource({
   draggingResource,
   dragDestinationDroppableId,
   hoveredGroupId,
+  nodeLatencies,
 }: {
   highlight?: boolean
   draggingResource?: DraggingResource | null
   dragDestinationDroppableId?: string | null
   hoveredGroupId?: string | null
+  nodeLatencies?: Record<string, NodeLatencyProbeResult>
 }) {
   const { t } = useTranslation()
   const { data: groupsQuery } = useGroupsQuery()
@@ -150,7 +153,9 @@ export function GroupResource({
           id: node.id,
           title,
           description: description || undefined,
-          meta: t('groupPicker.manualNode'),
+          meta: [t('groupPicker.manualNode'), formatLatencyMeta(nodeLatencies?.[node.id])]
+            .filter(Boolean)
+            .join(' · '),
           badge: node.protocol || undefined,
           keywords: [node.name, node.tag, node.address, node.protocol].filter(Boolean) as string[],
         }
@@ -171,7 +176,9 @@ export function GroupResource({
             id: node.id,
             title,
             description: description || undefined,
-            meta: t('groupPicker.fromSubscription', { name: subscriptionName }),
+            meta: [t('groupPicker.fromSubscription', { name: subscriptionName }), formatLatencyMeta(nodeLatencies?.[node.id])]
+              .filter(Boolean)
+              .join(' · '),
             badge: node.protocol || undefined,
             keywords: [node.name, node.tag, node.address, node.protocol, subscriptionName].filter(Boolean) as string[],
           }
@@ -179,7 +186,7 @@ export function GroupResource({
     })
 
     return [...manualNodeItems, ...subscriptionNodeItems]
-  }, [addingNodesGroup, nodes, subscriptions, t])
+  }, [addingNodesGroup, nodeLatencies, nodes, subscriptions, t])
 
   const addableSubscriptionItems = useMemo<GroupPickerItem[]>(() => {
     if (!addingSubscriptionsGroup) return []
@@ -290,6 +297,7 @@ export function GroupResource({
           groupId={groupId}
           nodes={groupNodes}
           subscriptions={groupSubscriptions}
+          nodeLatencies={nodeLatencies}
           allSubscriptions={subscriptionsQuery?.subscriptions}
           autoExpandValue={autoExpandValue}
           collapsed={!expandedGroupIds.has(groupId)}
@@ -399,4 +407,17 @@ export function GroupResource({
       />
     </Section>
   )
+}
+
+function formatLatencyMeta(result?: NodeLatencyProbeResult) {
+  if (!result) {
+    return undefined
+  }
+  if (typeof result.latencyMs === 'number') {
+    return `${result.latencyMs}ms`
+  }
+  if (result.message) {
+    return result.message === 'no latency result' ? 'N/A' : 'Fail'
+  }
+  return 'N/A'
 }

--- a/apps/web/src/pages/Orchestrate/Group.tsx
+++ b/apps/web/src/pages/Orchestrate/Group.tsx
@@ -36,6 +36,7 @@ import { DraggableResourceType } from '~/constants'
 import { useDisclosure } from '~/hooks'
 import { cn } from '~/lib/utils'
 import { getInstantDropStyle } from '~/utils'
+import { formatLatencyLabel, hasMeasuredLatency } from '~/utils/latency'
 import { appStateAtom, defaultResourcesAtom } from '~/store'
 
 const GROUP_DROPPABLE_ID = 'group-list'
@@ -153,10 +154,10 @@ export function GroupResource({
           id: node.id,
           title,
           description: description || undefined,
-          meta: [t('groupPicker.manualNode'), formatLatencyMeta(nodeLatencies?.[node.id])]
+          meta: [t('groupPicker.manualNode'), formatLatencyLabel(nodeLatencies?.[node.id], t)]
             .filter(Boolean)
             .join(' · '),
-          metaTone: nodeLatencies?.[node.id] ? 'primary' : 'default',
+          metaTone: hasMeasuredLatency(nodeLatencies?.[node.id]) ? 'primary' : 'default',
           badge: node.protocol || undefined,
           keywords: [node.name, node.tag, node.address, node.protocol].filter(Boolean) as string[],
         }
@@ -177,10 +178,10 @@ export function GroupResource({
             id: node.id,
             title,
             description: description || undefined,
-            meta: [t('groupPicker.fromSubscription', { name: subscriptionName }), formatLatencyMeta(nodeLatencies?.[node.id])]
+            meta: [t('groupPicker.fromSubscription', { name: subscriptionName }), formatLatencyLabel(nodeLatencies?.[node.id], t)]
               .filter(Boolean)
               .join(' · '),
-            metaTone: nodeLatencies?.[node.id] ? 'primary' : 'default',
+            metaTone: hasMeasuredLatency(nodeLatencies?.[node.id]) ? 'primary' : 'default',
             badge: node.protocol || undefined,
             keywords: [node.name, node.tag, node.address, node.protocol, subscriptionName].filter(Boolean) as string[],
           }
@@ -409,17 +410,4 @@ export function GroupResource({
       />
     </Section>
   )
-}
-
-function formatLatencyMeta(result?: NodeLatencyProbeResult) {
-  if (!result) {
-    return undefined
-  }
-  if (typeof result.latencyMs === 'number') {
-    return `${result.latencyMs}ms`
-  }
-  if (result.message) {
-    return result.message === 'no latency result' ? 'N/A' : 'Fail'
-  }
-  return 'N/A'
 }

--- a/apps/web/src/pages/Orchestrate/Node.tsx
+++ b/apps/web/src/pages/Orchestrate/Node.tsx
@@ -1,5 +1,6 @@
 import type { QRCodeModalRef } from '~/components/QRCodeModal.tsx'
 import type { NodesQuery } from '~/schemas/gql/graphql.ts'
+import type { NodeLatencyProbeResult } from '~/apis'
 import { Droppable } from '@hello-pangea/dnd'
 import { Cloud, CloudUpload, Eye, FileInput, Pencil } from 'lucide-react'
 import { Fragment, useRef, useState } from 'react'
@@ -19,9 +20,11 @@ export const NODE_DROPPABLE_ID = 'node-list'
 export function NodeResource({
   sortedNodes,
   highlight,
+  nodeLatencies,
 }: {
   sortedNodes: NodesQuery['nodes']['edges']
   highlight?: boolean
+  nodeLatencies?: Record<string, NodeLatencyProbeResult>
 }) {
   const { t } = useTranslation()
 
@@ -109,6 +112,11 @@ export function NodeResource({
                 }
                 onRemove={() => removeNodesMutation.mutate([id])}
               >
+                {nodeLatencies?.[id] && (
+                  <p className="text-xs font-medium text-primary">
+                    {formatLatencyDisplay(nodeLatencies[id], t('latency.unavailable'))}
+                  </p>
+                )}
                 {name && name !== tag && <p className="text-xs opacity-70">{name}</p>}
                 <Spoiler label={link} showLabel={t('actions.show sensitive')} hideLabel={t('actions.hide')} />
               </SortableNodeCard>
@@ -141,6 +149,13 @@ export function NodeResource({
       />
     </Section>
   )
+}
+
+function formatLatencyDisplay(result: NodeLatencyProbeResult, unavailableLabel: string) {
+  if (typeof result.latencyMs === 'number') {
+    return `${result.latencyMs} ms`
+  }
+  return result.message || unavailableLabel
 }
 
 function Spoiler({ label, showLabel, hideLabel }: { label: string; showLabel: string; hideLabel: string }) {

--- a/apps/web/src/pages/Orchestrate/Node.tsx
+++ b/apps/web/src/pages/Orchestrate/Node.tsx
@@ -14,6 +14,7 @@ import { Section } from '~/components/Section.tsx'
 import { Button } from '~/components/ui/button.tsx'
 import { SimpleTooltip } from '~/components/ui/tooltip.tsx'
 import { cn } from '~/lib/utils'
+import { formatLatencyLabel } from '~/utils/latency'
 
 export const NODE_DROPPABLE_ID = 'node-list'
 
@@ -114,7 +115,7 @@ export function NodeResource({
               >
                 {nodeLatencies?.[id] && (
                   <p className="text-xs font-medium text-primary">
-                    {formatLatencyDisplay(nodeLatencies[id], t('latency.unavailable'))}
+                    {formatLatencyLabel(nodeLatencies[id], t)}
                   </p>
                 )}
                 {name && name !== tag && <p className="text-xs opacity-70">{name}</p>}
@@ -149,13 +150,6 @@ export function NodeResource({
       />
     </Section>
   )
-}
-
-function formatLatencyDisplay(result: NodeLatencyProbeResult, unavailableLabel: string) {
-  if (typeof result.latencyMs === 'number') {
-    return `${result.latencyMs} ms`
-  }
-  return result.message || unavailableLabel
 }
 
 function Spoiler({ label, showLabel, hideLabel }: { label: string; showLabel: string; hideLabel: string }) {

--- a/apps/web/src/pages/Orchestrate/Subscription.tsx
+++ b/apps/web/src/pages/Orchestrate/Subscription.tsx
@@ -2,10 +2,11 @@ import type { QRCodeModalRef } from '~/components/QRCodeModal'
 import type { SubscriptionsQuery } from '~/schemas/gql/graphql'
 import { Droppable } from '@hello-pangea/dnd'
 import dayjs from 'dayjs'
-import { CloudCog, CloudUpload, Download, Eye, Pencil } from 'lucide-react'
+import { CloudCog, CloudUpload, Download, Eye, Gauge, Pencil } from 'lucide-react'
 import { Fragment, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  type NodeLatencyProbeResult,
   useImportSubscriptionsMutation,
   useRemoveSubscriptionsMutation,
   useSubscriptionsQuery,
@@ -29,8 +30,16 @@ import { cn } from '~/lib/utils'
 
 export function SubscriptionResource({
   sortedSubscriptions,
+  nodeLatencies,
+  testingLatencies,
+  lastLatencyProbeAt,
+  onTestAllNodeLatencies,
 }: {
   sortedSubscriptions: SubscriptionsQuery['subscriptions']
+  nodeLatencies?: Record<string, NodeLatencyProbeResult>
+  testingLatencies?: boolean
+  lastLatencyProbeAt?: string | null
+  onTestAllNodeLatencies: () => Promise<void>
 }) {
   const { t } = useTranslation()
 
@@ -68,20 +77,42 @@ export function SubscriptionResource({
       onCreate={openImportSubscriptionFormModal}
       bordered
       actions={
-        sortedSubscriptions.length > 2 && (
-          <SimpleTooltip label={t('actions.updateAll')}>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => {
-                updateSubscriptionsMutation.mutate(sortedSubscriptions.map(({ id }) => id))
-              }}
-              loading={updateSubscriptionsMutation.isPending}
+        <Fragment>
+          {sortedSubscriptions.length > 0 && (
+            <SimpleTooltip
+              label={
+                lastLatencyProbeAt
+                  ? `${t('latency.testAllNodes')} · ${t('latency.lastTested', { time: dayjs(lastLatencyProbeAt).format('HH:mm:ss') })} · ${t('latency.nodesMeasured', { count: Object.keys(nodeLatencies || {}).length })}`
+                  : t('latency.testAllNodes')
+              }
             >
-              <Download className="h-4 w-4" />
-            </Button>
-          </SimpleTooltip>
-        )
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  void onTestAllNodeLatencies()
+                }}
+                loading={testingLatencies}
+              >
+                <Gauge className="h-4 w-4" />
+              </Button>
+            </SimpleTooltip>
+          )}
+          {sortedSubscriptions.length > 2 && (
+            <SimpleTooltip label={t('actions.updateAll')}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => {
+                  updateSubscriptionsMutation.mutate(sortedSubscriptions.map(({ id }) => id))
+                }}
+                loading={updateSubscriptionsMutation.isPending}
+              >
+                <Download className="h-4 w-4" />
+              </Button>
+            </SimpleTooltip>
+          )}
+        </Fragment>
       }
     >
       <Droppable droppableId="subscription-list" type="SUBSCRIPTION">
@@ -172,6 +203,7 @@ export function SubscriptionResource({
                                   id={`subscription-node-${id}`}
                                   index={nodeIndex}
                                   name={name}
+                                  meta={formatLatencyMeta(nodeLatencies?.[id])}
                                 >
                                   {name}
                                 </DraggableResourceBadge>
@@ -241,6 +273,19 @@ export function SubscriptionResource({
       />
     </Section>
   )
+}
+
+function formatLatencyMeta(result?: NodeLatencyProbeResult) {
+  if (!result) {
+    return undefined
+  }
+  if (typeof result.latencyMs === 'number') {
+    return `${result.latencyMs}ms`
+  }
+  if (result.message) {
+    return result.message === 'no latency result' ? 'N/A' : 'Fail'
+  }
+  return 'N/A'
 }
 
 function Spoiler({ label, showLabel, hideLabel }: { label: string; showLabel: string; hideLabel: string }) {

--- a/apps/web/src/pages/Orchestrate/Subscription.tsx
+++ b/apps/web/src/pages/Orchestrate/Subscription.tsx
@@ -27,6 +27,7 @@ import { SimpleTooltip } from '~/components/ui/tooltip'
 import { UpdateSubscriptionAction } from '~/components/UpdateSubscriptionAction'
 import { useDisclosure } from '~/hooks'
 import { cn } from '~/lib/utils'
+import { formatLatencyLabel } from '~/utils/latency'
 
 export function SubscriptionResource({
   sortedSubscriptions,
@@ -82,7 +83,10 @@ export function SubscriptionResource({
             <SimpleTooltip
               label={
                 lastLatencyProbeAt
-                  ? `${t('latency.testAllNodes')} · ${t('latency.lastTested', { time: dayjs(lastLatencyProbeAt).format('HH:mm:ss') })} · ${t('latency.nodesMeasured', { count: Object.keys(nodeLatencies || {}).length })}`
+                  ? t('latency.testAllNodesWithStatus', {
+                      time: dayjs(lastLatencyProbeAt).format('HH:mm:ss'),
+                      count: Object.keys(nodeLatencies || {}).length,
+                    })
                   : t('latency.testAllNodes')
               }
             >
@@ -90,7 +94,9 @@ export function SubscriptionResource({
                 variant="ghost"
                 size="icon"
                 onClick={() => {
-                  void onTestAllNodeLatencies()
+                  onTestAllNodeLatencies().catch((error) => {
+                    console.error('Failed to test node latencies', error)
+                  })
                 }}
                 loading={testingLatencies}
               >
@@ -203,7 +209,7 @@ export function SubscriptionResource({
                                   id={`subscription-node-${id}`}
                                   index={nodeIndex}
                                   name={name}
-                                  meta={formatLatencyMeta(nodeLatencies?.[id])}
+                                  meta={formatLatencyLabel(nodeLatencies?.[id], t)}
                                 >
                                   {name}
                                 </DraggableResourceBadge>
@@ -273,19 +279,6 @@ export function SubscriptionResource({
       />
     </Section>
   )
-}
-
-function formatLatencyMeta(result?: NodeLatencyProbeResult) {
-  if (!result) {
-    return undefined
-  }
-  if (typeof result.latencyMs === 'number') {
-    return `${result.latencyMs}ms`
-  }
-  if (result.message) {
-    return result.message === 'no latency result' ? 'N/A' : 'Fail'
-  }
-  return 'N/A'
 }
 
 function Spoiler({ label, showLabel, hideLabel }: { label: string; showLabel: string; hideLabel: string }) {

--- a/apps/web/src/pages/Orchestrate/Subscription.tsx
+++ b/apps/web/src/pages/Orchestrate/Subscription.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs'
 import { CloudCog, CloudUpload, Download, Eye, Gauge, Pencil } from 'lucide-react'
 import { Fragment, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import {
   type NodeLatencyProbeResult,
   useImportSubscriptionsMutation,
@@ -96,6 +97,7 @@ export function SubscriptionResource({
                 onClick={() => {
                   onTestAllNodeLatencies().catch((error) => {
                     console.error('Failed to test node latencies', error)
+                    toast.error(error instanceof Error ? error.message : t('latency.unavailable'))
                   })
                 }}
                 loading={testingLatencies}

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -243,9 +243,9 @@ export function TrafficOverview() {
       </CardHeader>
 
       <CardContent className="px-4 py-4 sm:px-5 sm:py-4">
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
+        <div className="grid items-start gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
+          <div className="grid self-start gap-4 md:grid-cols-2">
+            <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
               <div className="mb-2 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.uploadChart')}</p>
@@ -253,7 +253,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-28 w-full"
+                className="mt-auto aspect-auto h-28 w-full"
               >
                 <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>
@@ -305,7 +305,7 @@ export function TrafficOverview() {
               </ChartContainer>
             </div>
 
-            <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
+            <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
               <div className="mb-2 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.downloadChart')}</p>
@@ -313,7 +313,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-28 w-full"
+                className="mt-auto aspect-auto h-28 w-full"
               >
                 <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -106,7 +106,7 @@ function TrafficMetricCard({
 }) {
   return (
     <div
-      className="rounded-2xl border bg-card px-4 py-2.5 shadow-sm transition-colors"
+      className="h-full rounded-2xl border bg-card px-4 py-2.5 shadow-sm transition-colors"
       style={createTintStyle(colorVar)}
     >
       <div className="flex items-center gap-3">
@@ -243,8 +243,8 @@ export function TrafficOverview() {
       </CardHeader>
 
       <CardContent className="px-4 py-4 sm:px-5 sm:py-4">
-        <div className="grid items-start gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
-          <div className="grid self-start gap-4 md:grid-cols-2">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
+          <div className="grid h-full gap-4 md:grid-cols-2">
             <div className="flex h-full flex-col rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
               <div className="mb-2 flex items-center justify-between gap-3">
                 <div>
@@ -253,7 +253,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="mt-auto aspect-auto h-28 w-full"
+                className="mt-2 flex-1 aspect-auto min-h-[180px] w-full"
               >
                 <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>
@@ -313,7 +313,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="mt-auto aspect-auto h-28 w-full"
+                className="mt-2 flex-1 aspect-auto min-h-[180px] w-full"
               >
                 <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>
@@ -366,7 +366,7 @@ export function TrafficOverview() {
             </div>
           </div>
 
-          <div className="grid auto-rows-min content-start self-start grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-2">
+          <div className="grid h-full auto-rows-fr grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-2">
             <TrafficMetricCard
               title={t('trafficOverview.uploadSpeed')}
               amount={uploadRateDisplay.amount}

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -30,7 +30,7 @@ import {
 import { Button } from '~/components/ui/button'
 import { cn } from '~/lib/utils'
 
-type TimeRangeKey = '10m' | '30m' | '1h'
+type TimeRangeKey = '1m' | '10m' | '30m' | '1h'
 
 interface TimeRangeOption {
   key: TimeRangeKey
@@ -40,6 +40,7 @@ interface TimeRangeOption {
 }
 
 const TIME_RANGE_OPTIONS: TimeRangeOption[] = [
+  { key: '1m', seconds: 60, maxPoints: 120, label: '1m' },
   { key: '10m', seconds: 10 * 60, maxPoints: 240, label: '10m' },
   { key: '30m', seconds: 30 * 60, maxPoints: 360, label: '30m' },
   { key: '1h', seconds: 60 * 60, maxPoints: 480, label: '1h' },
@@ -105,20 +106,20 @@ function TrafficMetricCard({
 }) {
   return (
     <div
-      className="rounded-2xl border bg-card px-4 py-3 shadow-sm transition-colors"
+      className="rounded-2xl border bg-card px-4 py-2.5 shadow-sm transition-colors"
       style={createTintStyle(colorVar)}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-center gap-3">
         <div
-          className="flex h-11 w-11 items-center justify-center rounded-2xl transition-colors"
+          className="flex h-10 w-10 items-center justify-center rounded-2xl transition-colors"
           style={createIconTintStyle(colorVar)}
         >
           {icon}
         </div>
         <div className="min-w-0">
           <p className="text-sm font-medium text-muted-foreground">{title}</p>
-          <div className="mt-1 flex items-baseline gap-2">
-            <span className="text-2xl font-extrabold tracking-tight text-foreground">{amount}</span>
+          <div className="mt-0.5 flex items-baseline gap-1.5">
+            <span className="text-[1.55rem] font-extrabold leading-none tracking-tight text-foreground">{amount}</span>
             <span className="text-sm text-muted-foreground">{unit}</span>
           </div>
         </div>
@@ -211,7 +212,7 @@ export function TrafficOverview() {
       padding="none"
       className="overflow-hidden border-border/80 bg-card/90 backdrop-blur-sm"
     >
-      <CardHeader className="gap-3 border-b border-border/70 px-6 py-5 sm:px-7">
+      <CardHeader className="gap-3 border-b border-border/70 px-6 py-4 sm:px-7">
         <div className="flex items-start gap-3">
           <div className="mt-0.5 rounded-full border border-primary/15 bg-primary/8 p-2 text-primary">
             <Activity className="h-5 w-5" />
@@ -234,11 +235,11 @@ export function TrafficOverview() {
         </div>
       </CardHeader>
 
-      <CardContent className="px-4 py-4 sm:px-5 sm:py-5">
+      <CardContent className="px-4 py-4 sm:px-5 sm:py-4">
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.85fr)_minmax(340px,1fr)]">
           <div className="grid gap-4">
-            <div className="rounded-2xl border border-border/70 bg-background/70 p-4 shadow-sm">
-              <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
+              <div className="mb-2.5 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.uploadChart')}</p>
                   <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
@@ -247,7 +248,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-32 w-full"
+                className="aspect-auto h-28 w-full"
               >
                 <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
                   <defs>
@@ -293,8 +294,8 @@ export function TrafficOverview() {
               </ChartContainer>
             </div>
 
-            <div className="rounded-2xl border border-border/70 bg-background/70 p-4 shadow-sm">
-              <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
+              <div className="mb-2.5 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.downloadChart')}</p>
                   <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
@@ -303,7 +304,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-32 w-full"
+                className="aspect-auto h-28 w-full"
               >
                 <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
                   <defs>

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -1,0 +1,401 @@
+import type { ChartConfig } from '~/components/ui/chart'
+import type { CSSProperties, ReactNode } from 'react'
+import dayjs from 'dayjs'
+import {
+  Activity,
+  ArrowDown,
+  ArrowUp,
+  Download,
+  Link2,
+  Radio,
+  Upload,
+} from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+
+import { useTrafficOverviewQuery } from '~/apis'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '~/components/ui/chart'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card'
+import { Button } from '~/components/ui/button'
+import { cn } from '~/lib/utils'
+
+type TimeRangeKey = '10m' | '30m' | '1h'
+
+interface TimeRangeOption {
+  key: TimeRangeKey
+  seconds: number
+  maxPoints: number
+  label: string
+}
+
+const TIME_RANGE_OPTIONS: TimeRangeOption[] = [
+  { key: '10m', seconds: 10 * 60, maxPoints: 120, label: '10m' },
+  { key: '30m', seconds: 30 * 60, maxPoints: 150, label: '30m' },
+  { key: '1h', seconds: 60 * 60, maxPoints: 180, label: '1h' },
+]
+
+function formatBytes(value: number) {
+  if (value < 1024) return `${value.toFixed(0)} B`
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)} KB`
+  if (value < 1024 ** 3) return `${(value / 1024 ** 2).toFixed(value < 10 * 1024 ** 2 ? 1 : 0)} MB`
+  return `${(value / 1024 ** 3).toFixed(1)} GB`
+}
+
+function formatRate(value: number) {
+  return `${formatBytes(value)}/s`
+}
+
+function formatAxisRate(value: number) {
+  if (value < 1024) return `${value.toFixed(0)}B`
+  if (value < 1024 ** 2) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)}K`
+  return `${(value / 1024 ** 2).toFixed(value < 10 * 1024 ** 2 ? 1 : 0)}M`
+}
+
+function splitFormattedRate(value: number) {
+  const formatted = formatRate(value)
+  const spaceIndex = formatted.indexOf(' ')
+
+  if (spaceIndex === -1) {
+    return { amount: formatted, unit: '' }
+  }
+
+  return {
+    amount: formatted.slice(0, spaceIndex),
+    unit: formatted.slice(spaceIndex + 1),
+  }
+}
+
+function createTintStyle(colorVar: string): CSSProperties {
+  return {
+    backgroundColor: `color-mix(in oklab, ${colorVar} 8%, var(--card))`,
+    borderColor: `color-mix(in oklab, ${colorVar} 16%, var(--border))`,
+  }
+}
+
+function createIconTintStyle(colorVar: string): CSSProperties {
+  return {
+    color: colorVar,
+    backgroundColor: `color-mix(in oklab, ${colorVar} 14%, transparent)`,
+  }
+}
+
+function TrafficMetricCard({
+  title,
+  amount,
+  unit,
+  icon,
+  colorVar,
+}: {
+  title: string
+  amount: string
+  unit: string
+  icon: ReactNode
+  colorVar: string
+}) {
+  return (
+    <div
+      className="rounded-2xl border bg-card px-4 py-3 shadow-sm transition-colors"
+      style={createTintStyle(colorVar)}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-11 w-11 items-center justify-center rounded-2xl transition-colors"
+          style={createIconTintStyle(colorVar)}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-muted-foreground">{title}</p>
+          <div className="mt-1 flex items-baseline gap-2">
+            <span className="text-2xl font-extrabold tracking-tight text-foreground">{amount}</span>
+            <span className="text-sm text-muted-foreground">{unit}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TrafficRangeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: string
+}) {
+  return (
+    <Button
+      variant="outline"
+      size="xs"
+      className={cn(
+        'rounded-full px-3 transition-colors',
+        active && 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15',
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  )
+}
+
+export function TrafficOverview() {
+  const { t } = useTranslation()
+  const [selectedRange, setSelectedRange] = useState<TimeRangeKey>('30m')
+
+  const chartConfig = useMemo(
+    () =>
+      ({
+        upload: { label: t('trafficOverview.uploadLegend'), color: 'var(--chart-1)' },
+        download: { label: t('trafficOverview.downloadLegend'), color: 'var(--chart-2)' },
+      }) satisfies ChartConfig,
+    [t],
+  )
+
+  const selectedWindow = useMemo(
+    () => TIME_RANGE_OPTIONS.find((option) => option.key === selectedRange) ?? TIME_RANGE_OPTIONS[1],
+    [selectedRange],
+  )
+
+  const trafficOverviewQuery = useTrafficOverviewQuery(selectedWindow.seconds, selectedWindow.maxPoints)
+  const runtimeOverview = trafficOverviewQuery.data
+
+  const latestSample = useMemo(
+    () => ({
+      uploadRate: runtimeOverview?.uploadRate ?? 0,
+      downloadRate: runtimeOverview?.downloadRate ?? 0,
+      uploadTotal: Number(runtimeOverview?.uploadTotal ?? 0),
+      downloadTotal: Number(runtimeOverview?.downloadTotal ?? 0),
+      activeConnections: runtimeOverview?.activeConnections ?? 0,
+      udpSessions: runtimeOverview?.udpSessions ?? 0,
+    }),
+    [runtimeOverview],
+  )
+
+  const uploadChartData = useMemo(
+    () =>
+      (runtimeOverview?.samples ?? []).map((sample) => ({
+        timestamp: dayjs(sample.timestamp).valueOf(),
+        value: sample.uploadRate,
+      })),
+    [runtimeOverview?.samples],
+  )
+  const downloadChartData = useMemo(
+    () =>
+      (runtimeOverview?.samples ?? []).map((sample) => ({
+        timestamp: dayjs(sample.timestamp).valueOf(),
+        value: sample.downloadRate,
+      })),
+    [runtimeOverview?.samples],
+  )
+
+  const uploadRateDisplay = splitFormattedRate(latestSample.uploadRate)
+  const downloadRateDisplay = splitFormattedRate(latestSample.downloadRate)
+
+  return (
+    <Card
+      withBorder
+      shadow="sm"
+      padding="none"
+      className="overflow-hidden border-border/80 bg-card/90 backdrop-blur-sm"
+    >
+      <CardHeader className="gap-3 border-b border-border/70 px-6 py-5 sm:px-7">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-full border border-primary/15 bg-primary/8 p-2 text-primary">
+            <Activity className="h-5 w-5" />
+          </div>
+          <div>
+            <CardTitle className="text-lg text-primary">{t('trafficOverview.title')}</CardTitle>
+            <CardDescription>{t('trafficOverview.description')}</CardDescription>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {TIME_RANGE_OPTIONS.map((option) => (
+            <TrafficRangeButton
+              key={option.key}
+              active={selectedRange === option.key}
+              onClick={() => setSelectedRange(option.key)}
+            >
+              {t(`trafficOverview.ranges.${option.key}`)}
+            </TrafficRangeButton>
+          ))}
+        </div>
+      </CardHeader>
+
+      <CardContent className="px-4 py-4 sm:px-5 sm:py-5">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.85fr)_minmax(340px,1fr)]">
+          <div className="grid gap-4">
+            <div className="rounded-2xl border border-border/70 bg-background/70 p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{t('trafficOverview.uploadChart')}</p>
+                  <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
+                </div>
+                <span className="text-xs font-medium text-[var(--chart-1)]">{t('trafficOverview.uploadLegend')}</span>
+              </div>
+              <ChartContainer
+                config={chartConfig}
+                className="aspect-auto h-32 w-full"
+              >
+                <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
+                  <defs>
+                    <linearGradient id="traffic-upload-fill" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="var(--color-upload)" stopOpacity={0.22} />
+                      <stop offset="100%" stopColor="var(--color-upload)" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="timestamp"
+                    axisLine={false}
+                    tickLine={false}
+                    minTickGap={24}
+                    tickFormatter={(value) => dayjs(value).format('HH:mm')}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tickMargin={10}
+                    width={60}
+                    tickFormatter={(value) => formatAxisRate(Number(value))}
+                    domain={[0, (dataMax: number) => Math.max(16 * 1024, dataMax * 1.15)]}
+                  />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        labelFormatter={(value) => dayjs(Number(value)).format('HH:mm:ss')}
+                        formatter={(value) => formatRate(Number(value))}
+                        indicator="line"
+                      />
+                    }
+                  />
+                  <Area
+                    dataKey="value"
+                    type="monotone"
+                    stroke="var(--color-upload)"
+                    strokeWidth={2.5}
+                    fill="url(#traffic-upload-fill)"
+                    isAnimationActive={false}
+                  />
+                </AreaChart>
+              </ChartContainer>
+            </div>
+
+            <div className="rounded-2xl border border-border/70 bg-background/70 p-4 shadow-sm">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{t('trafficOverview.downloadChart')}</p>
+                  <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
+                </div>
+                <span className="text-xs font-medium text-[var(--chart-2)]">{t('trafficOverview.downloadLegend')}</span>
+              </div>
+              <ChartContainer
+                config={chartConfig}
+                className="aspect-auto h-32 w-full"
+              >
+                <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
+                  <defs>
+                    <linearGradient id="traffic-download-fill" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="var(--color-download)" stopOpacity={0.2} />
+                      <stop offset="100%" stopColor="var(--color-download)" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="timestamp"
+                    axisLine={false}
+                    tickLine={false}
+                    minTickGap={24}
+                    tickFormatter={(value) => dayjs(value).format('HH:mm')}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tickMargin={10}
+                    width={60}
+                    tickFormatter={(value) => formatAxisRate(Number(value))}
+                    domain={[0, (dataMax: number) => Math.max(32 * 1024, dataMax * 1.15)]}
+                  />
+                  <ChartTooltip
+                    content={
+                      <ChartTooltipContent
+                        labelFormatter={(value) => dayjs(Number(value)).format('HH:mm:ss')}
+                        formatter={(value) => formatRate(Number(value))}
+                        indicator="line"
+                      />
+                    }
+                  />
+                  <Area
+                    dataKey="value"
+                    type="monotone"
+                    stroke="var(--color-download)"
+                    strokeWidth={2.5}
+                    fill="url(#traffic-download-fill)"
+                    isAnimationActive={false}
+                  />
+                </AreaChart>
+              </ChartContainer>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-2">
+            <TrafficMetricCard
+              title={t('trafficOverview.uploadSpeed')}
+              amount={uploadRateDisplay.amount}
+              unit={uploadRateDisplay.unit}
+              icon={<ArrowUp className="h-5 w-5" />}
+              colorVar="var(--chart-1)"
+            />
+            <TrafficMetricCard
+              title={t('trafficOverview.downloadSpeed')}
+              amount={downloadRateDisplay.amount}
+              unit={downloadRateDisplay.unit}
+              icon={<ArrowDown className="h-5 w-5" />}
+              colorVar="var(--chart-2)"
+            />
+            <TrafficMetricCard
+              title={t('trafficOverview.activeConnections')}
+              amount={latestSample.activeConnections.toString()}
+              unit={t('trafficOverview.connectionsUnit')}
+              icon={<Link2 className="h-5 w-5" />}
+              colorVar="var(--primary)"
+            />
+            <TrafficMetricCard
+              title={t('trafficOverview.totalUpload')}
+              amount={formatBytes(latestSample.uploadTotal).split(' ')[0]}
+              unit={formatBytes(latestSample.uploadTotal).split(' ')[1] ?? ''}
+              icon={<Upload className="h-5 w-5" />}
+              colorVar="var(--chart-1)"
+            />
+            <TrafficMetricCard
+              title={t('trafficOverview.totalDownload')}
+              amount={formatBytes(latestSample.downloadTotal).split(' ')[0]}
+              unit={formatBytes(latestSample.downloadTotal).split(' ')[1] ?? ''}
+              icon={<Download className="h-5 w-5" />}
+              colorVar="var(--chart-2)"
+            />
+            <TrafficMetricCard
+              title={t('trafficOverview.udpSessions')}
+              amount={latestSample.udpSessions.toString()}
+              unit={t('trafficOverview.sessionsUnit')}
+              icon={<Radio className="h-5 w-5" />}
+              colorVar="var(--chart-3)"
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -77,6 +77,25 @@ function splitFormattedRate(value: number) {
   }
 }
 
+function splitFormattedBytes(value: number) {
+  const formatted = formatBytes(value)
+  const spaceIndex = formatted.indexOf(' ')
+
+  if (spaceIndex === -1) {
+    return { amount: formatted, unit: '' }
+  }
+
+  return {
+    amount: formatted.slice(0, spaceIndex),
+    unit: formatted.slice(spaceIndex + 1),
+  }
+}
+
+function safeParseMetricTotal(value?: string) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
 function createTintStyle(colorVar: string): CSSProperties {
   return {
     backgroundColor: `color-mix(in oklab, ${colorVar} 8%, var(--card))`,
@@ -166,7 +185,7 @@ export function TrafficOverview() {
   )
 
   const selectedWindow = useMemo(
-    () => TIME_RANGE_OPTIONS.find((option) => option.key === selectedRange) ?? TIME_RANGE_OPTIONS[1],
+    () => TIME_RANGE_OPTIONS.find((option) => option.key === selectedRange) ?? TIME_RANGE_OPTIONS[0],
     [selectedRange],
   )
 
@@ -185,8 +204,8 @@ export function TrafficOverview() {
     () => ({
       uploadRate: runtimeOverview?.uploadRate ?? 0,
       downloadRate: runtimeOverview?.downloadRate ?? 0,
-      uploadTotal: Number(runtimeOverview?.uploadTotal ?? 0),
-      downloadTotal: Number(runtimeOverview?.downloadTotal ?? 0),
+      uploadTotal: safeParseMetricTotal(runtimeOverview?.uploadTotal),
+      downloadTotal: safeParseMetricTotal(runtimeOverview?.downloadTotal),
       activeConnections: runtimeOverview?.activeConnections ?? 0,
       udpSessions: runtimeOverview?.udpSessions ?? 0,
     }),
@@ -212,6 +231,8 @@ export function TrafficOverview() {
 
   const uploadRateDisplay = splitFormattedRate(latestSample.uploadRate)
   const downloadRateDisplay = splitFormattedRate(latestSample.downloadRate)
+  const uploadTotalDisplay = splitFormattedBytes(latestSample.uploadTotal)
+  const downloadTotalDisplay = splitFormattedBytes(latestSample.downloadTotal)
 
   return (
     <Card
@@ -390,15 +411,15 @@ export function TrafficOverview() {
             />
             <TrafficMetricCard
               title={t('trafficOverview.totalUpload')}
-              amount={formatBytes(latestSample.uploadTotal).split(' ')[0]}
-              unit={formatBytes(latestSample.uploadTotal).split(' ')[1] ?? ''}
+              amount={uploadTotalDisplay.amount}
+              unit={uploadTotalDisplay.unit}
               icon={<Upload className="h-5 w-5" />}
               colorVar="var(--chart-1)"
             />
             <TrafficMetricCard
               title={t('trafficOverview.totalDownload')}
-              amount={formatBytes(latestSample.downloadTotal).split(' ')[0]}
-              unit={formatBytes(latestSample.downloadTotal).split(' ')[1] ?? ''}
+              amount={downloadTotalDisplay.amount}
+              unit={downloadTotalDisplay.unit}
               icon={<Download className="h-5 w-5" />}
               colorVar="var(--chart-2)"
             />

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -258,7 +258,7 @@ export function TrafficOverview() {
                 config={chartConfig}
                 className="aspect-auto h-24 w-full"
               >
-                <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
+                <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 18 }}>
                   <defs>
                     <linearGradient id="traffic-upload-fill" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="0%" stopColor="var(--color-upload)" stopOpacity={0.22} />
@@ -273,6 +273,8 @@ export function TrafficOverview() {
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
+                    tickMargin={14}
+                    height={28}
                     domain={[chartWindowStart, chartWindowEnd]}
                     allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}
@@ -318,7 +320,7 @@ export function TrafficOverview() {
                 config={chartConfig}
                 className="aspect-auto h-24 w-full"
               >
-                <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
+                <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 18 }}>
                   <defs>
                     <linearGradient id="traffic-download-fill" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="0%" stopColor="var(--color-download)" stopOpacity={0.2} />
@@ -333,6 +335,8 @@ export function TrafficOverview() {
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
+                    tickMargin={14}
+                    height={28}
                     domain={[chartWindowStart, chartWindowEnd]}
                     allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -154,7 +154,7 @@ function TrafficRangeButton({
 
 export function TrafficOverview() {
   const { t } = useTranslation()
-  const [selectedRange, setSelectedRange] = useState<TimeRangeKey>('30m')
+  const [selectedRange, setSelectedRange] = useState<TimeRangeKey>('1m')
 
   const chartConfig = useMemo(
     () =>

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -172,6 +172,14 @@ export function TrafficOverview() {
 
   const trafficOverviewQuery = useTrafficOverviewQuery(selectedWindow.seconds, selectedWindow.maxPoints)
   const runtimeOverview = trafficOverviewQuery.data
+  const chartWindowEnd = useMemo(
+    () => (runtimeOverview?.updatedAt ? dayjs(runtimeOverview.updatedAt).valueOf() : Date.now()),
+    [runtimeOverview?.updatedAt],
+  )
+  const chartWindowStart = useMemo(
+    () => chartWindowEnd - selectedWindow.seconds * 1000,
+    [chartWindowEnd, selectedWindow.seconds],
+  )
 
   const latestSample = useMemo(
     () => ({
@@ -236,8 +244,8 @@ export function TrafficOverview() {
       </CardHeader>
 
       <CardContent className="px-4 py-4 sm:px-5 sm:py-4">
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.85fr)_minmax(340px,1fr)]">
-          <div className="grid gap-4">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
+          <div className="grid gap-4 md:grid-cols-2">
             <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
               <div className="mb-2.5 flex items-center justify-between gap-3">
                 <div>
@@ -248,7 +256,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-28 w-full"
+                className="aspect-auto h-24 w-full"
               >
                 <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
                   <defs>
@@ -259,10 +267,14 @@ export function TrafficOverview() {
                   </defs>
                   <CartesianGrid vertical={false} strokeDasharray="3 3" />
                   <XAxis
+                    type="number"
+                    scale="time"
                     dataKey="timestamp"
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
+                    domain={[chartWindowStart, chartWindowEnd]}
+                    allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}
                   />
                   <YAxis
@@ -304,7 +316,7 @@ export function TrafficOverview() {
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-28 w-full"
+                className="aspect-auto h-24 w-full"
               >
                 <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 4 }}>
                   <defs>
@@ -315,10 +327,14 @@ export function TrafficOverview() {
                   </defs>
                   <CartesianGrid vertical={false} strokeDasharray="3 3" />
                   <XAxis
+                    type="number"
+                    scale="time"
                     dataKey="timestamp"
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
+                    domain={[chartWindowStart, chartWindowEnd]}
+                    allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}
                   />
                   <YAxis
@@ -351,7 +367,7 @@ export function TrafficOverview() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-2">
+          <div className="grid auto-rows-min content-start self-start grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-2">
             <TrafficMetricCard
               title={t('trafficOverview.uploadSpeed')}
               amount={uploadRateDisplay.amount}

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -40,9 +40,9 @@ interface TimeRangeOption {
 }
 
 const TIME_RANGE_OPTIONS: TimeRangeOption[] = [
-  { key: '10m', seconds: 10 * 60, maxPoints: 120, label: '10m' },
-  { key: '30m', seconds: 30 * 60, maxPoints: 150, label: '30m' },
-  { key: '1h', seconds: 60 * 60, maxPoints: 180, label: '1h' },
+  { key: '10m', seconds: 10 * 60, maxPoints: 240, label: '10m' },
+  { key: '30m', seconds: 30 * 60, maxPoints: 360, label: '30m' },
+  { key: '1h', seconds: 60 * 60, maxPoints: 480, label: '1h' },
 ]
 
 function formatBytes(value: number) {

--- a/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
+++ b/apps/web/src/pages/Orchestrate/TrafficOverview.tsx
@@ -227,7 +227,6 @@ export function TrafficOverview() {
           </div>
           <div>
             <CardTitle className="text-lg text-primary">{t('trafficOverview.title')}</CardTitle>
-            <CardDescription>{t('trafficOverview.description')}</CardDescription>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -247,18 +246,16 @@ export function TrafficOverview() {
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(340px,1fr)]">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
-              <div className="mb-2.5 flex items-center justify-between gap-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.uploadChart')}</p>
-                  <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
                 </div>
-                <span className="text-xs font-medium text-[var(--chart-1)]">{t('trafficOverview.uploadLegend')}</span>
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-24 w-full"
+                className="aspect-auto h-28 w-full"
               >
-                <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 18 }}>
+                <AreaChart data={uploadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>
                     <linearGradient id="traffic-upload-fill" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="0%" stopColor="var(--color-upload)" stopOpacity={0.22} />
@@ -273,8 +270,8 @@ export function TrafficOverview() {
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
-                    tickMargin={14}
-                    height={28}
+                    tickMargin={18}
+                    height={34}
                     domain={[chartWindowStart, chartWindowEnd]}
                     allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}
@@ -309,18 +306,16 @@ export function TrafficOverview() {
             </div>
 
             <div className="rounded-2xl border border-border/70 bg-background/70 p-3.5 shadow-sm">
-              <div className="mb-2.5 flex items-center justify-between gap-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-foreground">{t('trafficOverview.downloadChart')}</p>
-                  <p className="text-xs text-muted-foreground">{t('trafficOverview.liveWindow')}</p>
                 </div>
-                <span className="text-xs font-medium text-[var(--chart-2)]">{t('trafficOverview.downloadLegend')}</span>
               </div>
               <ChartContainer
                 config={chartConfig}
-                className="aspect-auto h-24 w-full"
+                className="aspect-auto h-28 w-full"
               >
-                <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 18 }}>
+                <AreaChart data={downloadChartData} margin={{ left: 4, right: 4, top: 4, bottom: 2 }}>
                   <defs>
                     <linearGradient id="traffic-download-fill" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="0%" stopColor="var(--color-download)" stopOpacity={0.2} />
@@ -335,8 +330,8 @@ export function TrafficOverview() {
                     axisLine={false}
                     tickLine={false}
                     minTickGap={24}
-                    tickMargin={14}
-                    height={28}
+                    tickMargin={18}
+                    height={34}
                     domain={[chartWindowStart, chartWindowEnd]}
                     allowDataOverflow
                     tickFormatter={(value) => dayjs(value).format('HH:mm')}

--- a/apps/web/src/pages/Orchestrate/index.tsx
+++ b/apps/web/src/pages/Orchestrate/index.tsx
@@ -596,6 +596,7 @@ export function OrchestratePage() {
             draggingResource={draggingResource}
             dragDestinationDroppableId={dragDestinationDroppableId}
             hoveredGroupId={hoveredGroupId}
+            nodeLatencies={nodeLatencies}
           />
           <NodeResource
             sortedNodes={sortedNodes}

--- a/apps/web/src/pages/Orchestrate/index.tsx
+++ b/apps/web/src/pages/Orchestrate/index.tsx
@@ -21,6 +21,7 @@ import { GroupResource } from './Group'
 import { NODE_DROPPABLE_ID, NodeResource } from './Node'
 import { Routing } from './Routing'
 import { SubscriptionResource } from './Subscription'
+import { TrafficOverview } from './TrafficOverview'
 
 function arrayMove<T>(array: T[], from: number, to: number): T[] {
   const newArray = [...array]
@@ -574,6 +575,8 @@ export function OrchestratePage() {
         <DNS />
         <Routing />
       </div>
+
+      <TrafficOverview />
 
       <DragDropContext onDragStart={onDragStart} onDragUpdate={onDragUpdate} onDragEnd={onDragEnd}>
         <div className={`grid gap-5 ${matchSmallScreen ? 'grid-cols-1' : 'grid-cols-3'}`}>

--- a/apps/web/src/pages/Orchestrate/index.tsx
+++ b/apps/web/src/pages/Orchestrate/index.tsx
@@ -3,20 +3,24 @@ import type { DraggingResource } from '~/constants'
 import type { GroupsQuery, NodesQuery, SubscriptionsQuery } from '~/schemas/gql/graphql'
 import { DragDropContext } from '@hello-pangea/dnd'
 import { useStore } from '@nanostores/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  useConfigsQuery,
   useGroupAddNodesMutation,
   useGroupAddSubscriptionsMutation,
   useGroupDelNodesMutation,
   useGroupsQuery,
+  useNodeLatenciesQuery,
   useNodesQuery,
   useSubscriptionsQuery,
   useTestNodeLatenciesMutation,
 } from '~/apis'
 import type { NodeLatencyProbeResult } from '~/apis'
-import { DraggableResourceType } from '~/constants'
+import { DraggableResourceType, QUERY_KEY_NODE_LATENCY } from '~/constants'
 import { useMediaQuery } from '~/hooks'
 import { appStateAtom, groupSortOrdersAtom } from '~/store'
+import { deriveTime } from '~/utils'
 import { Config } from './Config'
 import { DNS } from './DNS'
 import { GroupResource } from './Group'
@@ -33,6 +37,8 @@ function arrayMove<T>(array: T[], from: number, to: number): T[] {
 }
 
 export function OrchestratePage() {
+  const queryClient = useQueryClient()
+  const { data: configsQuery } = useConfigsQuery()
   const { data: nodesQuery } = useNodesQuery()
   const { data: groupsQuery } = useGroupsQuery()
   const { data: subscriptionsQuery } = useSubscriptionsQuery()
@@ -46,7 +52,6 @@ export function OrchestratePage() {
   const [isDragging, setIsDragging] = useState(false)
   const [dragDestinationDroppableId, setDragDestinationDroppableId] = useState<string | null>(null)
   const [hoveredGroupId, setHoveredGroupId] = useState<string | null>(null)
-  const [nodeLatencies, setNodeLatencies] = useState<Record<string, NodeLatencyProbeResult>>({})
   const autoScrollFrameRef = useRef<number | null>(null)
   const draggingActiveRef = useRef(false)
   const edgeAutoScrollEnabledRef = useRef(false)
@@ -88,6 +93,22 @@ export function OrchestratePage() {
   const hasGroupSubscription = useCallback(
     (groupId: string, subscriptionId: string) => !!getGroupSubscriptionBinding(groupId, subscriptionId),
     [getGroupSubscriptionBinding],
+  )
+  const selectedConfig = useMemo(
+    () => configsQuery?.configs.find((config) => config.selected),
+    [configsQuery?.configs],
+  )
+  const nodeLatencyRefetchIntervalMs = useMemo(() => {
+    const configuredInterval = selectedConfig?.global.checkInterval
+    if (!configuredInterval) return 30_000
+
+    const ms = deriveTime(configuredInterval, 'ms')
+    return Math.max(1_000, Number.isFinite(ms) ? ms : 30_000)
+  }, [selectedConfig?.global.checkInterval])
+  const nodeLatenciesQuery = useNodeLatenciesQuery(nodeLatencyRefetchIntervalMs)
+  const nodeLatencies = useMemo<Record<string, NodeLatencyProbeResult>>(
+    () => Object.fromEntries((nodeLatenciesQuery.data ?? []).map((result) => [result.id, result])),
+    [nodeLatenciesQuery.data],
   )
   const lastLatencyProbeAt = useMemo(() => {
     const testedAtList = Object.values(nodeLatencies)
@@ -609,10 +630,9 @@ export function OrchestratePage() {
             testingLatencies={testNodeLatenciesMutation.isPending}
             lastLatencyProbeAt={lastLatencyProbeAt}
             onTestAllNodeLatencies={async () => {
-              const results = await testNodeLatenciesMutation.mutateAsync()
-              setNodeLatencies(
-                Object.fromEntries(results.map((result) => [result.id, result])),
-              )
+              await testNodeLatenciesMutation.mutateAsync()
+              await queryClient.invalidateQueries({ queryKey: QUERY_KEY_NODE_LATENCY })
+              await nodeLatenciesQuery.refetch()
             }}
           />
         </div>

--- a/apps/web/src/pages/Orchestrate/index.tsx
+++ b/apps/web/src/pages/Orchestrate/index.tsx
@@ -11,7 +11,9 @@ import {
   useGroupsQuery,
   useNodesQuery,
   useSubscriptionsQuery,
+  useTestNodeLatenciesMutation,
 } from '~/apis'
+import type { NodeLatencyProbeResult } from '~/apis'
 import { DraggableResourceType } from '~/constants'
 import { useMediaQuery } from '~/hooks'
 import { appStateAtom, groupSortOrdersAtom } from '~/store'
@@ -38,11 +40,13 @@ export function OrchestratePage() {
   const groupAddNodesMutation = useGroupAddNodesMutation()
   const groupAddSubscriptionsMutation = useGroupAddSubscriptionsMutation()
   const groupDelNodesMutation = useGroupDelNodesMutation()
+  const testNodeLatenciesMutation = useTestNodeLatenciesMutation()
 
   const [draggingResource, setDraggingResource] = useState<DraggingResource | null>(null)
   const [isDragging, setIsDragging] = useState(false)
   const [dragDestinationDroppableId, setDragDestinationDroppableId] = useState<string | null>(null)
   const [hoveredGroupId, setHoveredGroupId] = useState<string | null>(null)
+  const [nodeLatencies, setNodeLatencies] = useState<Record<string, NodeLatencyProbeResult>>({})
   const autoScrollFrameRef = useRef<number | null>(null)
   const draggingActiveRef = useRef(false)
   const edgeAutoScrollEnabledRef = useRef(false)
@@ -85,6 +89,13 @@ export function OrchestratePage() {
     (groupId: string, subscriptionId: string) => !!getGroupSubscriptionBinding(groupId, subscriptionId),
     [getGroupSubscriptionBinding],
   )
+  const lastLatencyProbeAt = useMemo(() => {
+    const testedAtList = Object.values(nodeLatencies)
+      .map((item) => item.testedAt)
+      .filter(Boolean)
+      .sort()
+    return testedAtList[testedAtList.length - 1] ?? null
+  }, [nodeLatencies])
 
   // Get sorted node IDs
   const sortedNodeIds = useMemo(() => {
@@ -589,8 +600,20 @@ export function OrchestratePage() {
           <NodeResource
             sortedNodes={sortedNodes}
             highlight={draggingResource?.type === DraggableResourceType.groupNode}
+            nodeLatencies={nodeLatencies}
           />
-          <SubscriptionResource sortedSubscriptions={sortedSubscriptions} />
+          <SubscriptionResource
+            sortedSubscriptions={sortedSubscriptions}
+            nodeLatencies={nodeLatencies}
+            testingLatencies={testNodeLatenciesMutation.isPending}
+            lastLatencyProbeAt={lastLatencyProbeAt}
+            onTestAllNodeLatencies={async () => {
+              const results = await testNodeLatenciesMutation.mutateAsync()
+              setNodeLatencies(
+                Object.fromEntries(results.map((result) => [result.id, result])),
+              )
+            }}
+          />
         </div>
       </DragDropContext>
     </div>

--- a/apps/web/src/pages/Orchestrate/index.tsx
+++ b/apps/web/src/pages/Orchestrate/index.tsx
@@ -3,7 +3,6 @@ import type { DraggingResource } from '~/constants'
 import type { GroupsQuery, NodesQuery, SubscriptionsQuery } from '~/schemas/gql/graphql'
 import { DragDropContext } from '@hello-pangea/dnd'
 import { useStore } from '@nanostores/react'
-import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   useConfigsQuery,
@@ -17,7 +16,7 @@ import {
   useTestNodeLatenciesMutation,
 } from '~/apis'
 import type { NodeLatencyProbeResult } from '~/apis'
-import { DraggableResourceType, QUERY_KEY_NODE_LATENCY } from '~/constants'
+import { DraggableResourceType } from '~/constants'
 import { useMediaQuery } from '~/hooks'
 import { appStateAtom, groupSortOrdersAtom } from '~/store'
 import { deriveTime } from '~/utils'
@@ -37,7 +36,6 @@ function arrayMove<T>(array: T[], from: number, to: number): T[] {
 }
 
 export function OrchestratePage() {
-  const queryClient = useQueryClient()
   const { data: configsQuery } = useConfigsQuery()
   const { data: nodesQuery } = useNodesQuery()
   const { data: groupsQuery } = useGroupsQuery()
@@ -111,11 +109,19 @@ export function OrchestratePage() {
     [nodeLatenciesQuery.data],
   )
   const lastLatencyProbeAt = useMemo(() => {
-    const testedAtList = Object.values(nodeLatencies)
-      .map((item) => item.testedAt)
-      .filter(Boolean)
-      .sort()
-    return testedAtList[testedAtList.length - 1] ?? null
+    let latest: string | null = null
+    let latestMs = -Infinity
+
+    for (const { testedAt } of Object.values(nodeLatencies)) {
+      if (!testedAt) continue
+      const ms = Date.parse(testedAt)
+      if (Number.isFinite(ms) && ms > latestMs) {
+        latestMs = ms
+        latest = testedAt
+      }
+    }
+
+    return latest
   }, [nodeLatencies])
 
   // Get sorted node IDs
@@ -631,8 +637,6 @@ export function OrchestratePage() {
             lastLatencyProbeAt={lastLatencyProbeAt}
             onTestAllNodeLatencies={async () => {
               await testNodeLatenciesMutation.mutateAsync()
-              await queryClient.invalidateQueries({ queryKey: QUERY_KEY_NODE_LATENCY })
-              await nodeLatenciesQuery.refetch()
             }}
           />
         </div>

--- a/apps/web/src/schemas/gql/graphql.ts
+++ b/apps/web/src/schemas/gql/graphql.ts
@@ -2148,11 +2148,6 @@ export const GroupAddNodesDocument = {
             },
           },
         },
-        {
-          kind: 'VariableDefinition',
-          variable: { kind: 'Variable', name: { kind: 'Name', value: 'nameFilterRegex' } },
-          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
-        },
       ],
       selectionSet: {
         kind: 'SelectionSet',

--- a/apps/web/src/utils/latency.ts
+++ b/apps/web/src/utils/latency.ts
@@ -1,0 +1,19 @@
+import type { TFunction } from 'i18next'
+import type { NodeLatencyProbeResult } from '~/apis'
+
+export function hasMeasuredLatency(result?: NodeLatencyProbeResult) {
+  return typeof result?.latencyMs === 'number'
+}
+
+export function formatLatencyLabel(result: NodeLatencyProbeResult | undefined, t: TFunction) {
+  if (!result) {
+    return undefined
+  }
+  if (typeof result.latencyMs === 'number') {
+    return `${result.latencyMs} ms`
+  }
+  if (result.alive === false) {
+    return t('latency.failed')
+  }
+  return t('latency.unavailable')
+}

--- a/apps/web/src/utils/latency.ts
+++ b/apps/web/src/utils/latency.ts
@@ -2,7 +2,7 @@ import type { TFunction } from 'i18next'
 import type { NodeLatencyProbeResult } from '~/apis'
 
 export function hasMeasuredLatency(result?: NodeLatencyProbeResult) {
-  return typeof result?.latencyMs === 'number'
+  return Number.isFinite(result?.latencyMs)
 }
 
 export function formatLatencyLabel(result: NodeLatencyProbeResult | undefined, t: TFunction) {


### PR DESCRIPTION
## Summary

This PR adds runtime traffic overview and node latency UI support to Orchestrate.

It consumes the corresponding `dae-wing` traffic/latency APIs and surfaces:

- runtime traffic overview charts and counters
- manual node latency testing
- latency display in node / subscription / group views

## What changed

- add `TrafficOverview` to Orchestrate
- show runtime upload/download rates and totals
- show active connections and UDP sessions
- render sampled traffic history for charting
- add manual node latency probe action in subscription section
- query persisted node latency results from backend
- display latency in:
  - node cards
  - subscription node badges
  - group node items
  - group picker node metadata
- default traffic overview window to `1m`
- refine traffic chart layout, labels, and alignment

## Traffic overview

This PR adds a runtime traffic panel to the Orchestrate page.

It includes:
- upload/download speed
- accumulated upload/download traffic
- active TCP connections
- UDP sessions
- rolling sampled history for charts
- switchable time windows

## Node latency UI

This PR adds frontend support for node latency testing and display.

It includes:
- trigger action for manual node latency probing
- query-driven latency refresh
- latency badges in node/subscription/group contexts
- latency highlighting in group picker

## Dependency

This PR depends on the corresponding `dae-wing` API layer:

- dae-wing PR: <https://github.com/daeuniverse/dae-wing/pull/192>

That backend PR depends on the already-merged `dae` runtime/control-plane support.

## Notes

- this PR uses backend `nodeLatencies` query data instead of keeping latency results only in local page state
- runtime traffic overview and latency display are intentionally grouped together because they share the same backend dependency chain
- this PR also includes a small generated document fix for `GroupAddNodesDocument` so this branch does not depend on daed #741 being merged first

## Manual verification

- [ ] open Orchestrate and confirm traffic overview renders
- [ ] switch time windows and confirm chart updates
- [ ] confirm traffic counters update while runtime traffic is active
- [ ] trigger manual node latency test and confirm latency values appear
- [ ] confirm latency is shown in node cards
- [ ] confirm latency is shown in subscription node badges
- [ ] confirm latency is shown in group nodes and group picker metadata
- [ ] confirm no obvious regression in existing orchestrate drag/group behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node latency testing: trigger probes, “Test Latency” and “Test all nodes” controls, and per-node latency badges/status.
  * Traffic overview dashboard: real-time upload/download charts, selectable ranges (1m/10m/30m/1h) and key metric cards.

* **Improvements**
  * Latency display and tones added across resource badges, lists, and pages; periodic background refresh for latency data.

* **Localization**
  * Added English and Simplified Chinese strings for latency and traffic overview UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->